### PR TITLE
Fixed #117 - Type does not have a default constructor, when map to target instance

### DIFF
--- a/src/Mapster.Tests/WhenUsingNonDefaultConstructor.cs
+++ b/src/Mapster.Tests/WhenUsingNonDefaultConstructor.cs
@@ -59,6 +59,18 @@ namespace Mapster.Tests
             dto.Unmapped.ShouldBe("unmapped");
         }
 
+        [TestMethod]
+        public void Map_To_Existing_Destination_Instance_Should_Pass()
+        {
+            var simplePoco = new SimplePoco { Id = Guid.NewGuid(), Name = "TestName" };
+
+            var dto = new SimpleDtoWithoutDefaultConstructor("unmapped");
+            simplePoco.Adapt(dto);
+
+            dto.Id.ShouldBe(simplePoco.Id);
+            dto.Name.ShouldBe(simplePoco.Name);
+            dto.Unmapped.ShouldBe("unmapped");
+        }
 
         #region TestClasses
 
@@ -89,6 +101,19 @@ namespace Mapster.Tests
             public Guid Id { get; set; }
             public string Name { get; set; }
 
+            public string Unmapped { get; set; }
+        }
+
+        public class SimpleDtoWithoutDefaultConstructor
+        {       
+
+            public SimpleDtoWithoutDefaultConstructor(string unmapped)
+            {
+                Unmapped = unmapped;
+            }
+
+            public Guid Id { get; set; }
+            public string Name { get; set; }
             public string Unmapped { get; set; }
         }
 

--- a/src/Mapster.Tests/WhenUsingNonDefaultConstructor.cs
+++ b/src/Mapster.Tests/WhenUsingNonDefaultConstructor.cs
@@ -16,7 +16,7 @@ namespace Mapster.Tests
                 .ConstructUsing(src => new SimpleDtoWithDefaultConstructor("unmapped"))
                 .Compile();
 
-            var simplePoco = new SimplePoco {Id = Guid.NewGuid(), Name = "TestName"};
+            var simplePoco = new SimplePoco { Id = Guid.NewGuid(), Name = "TestName" };
 
             var dto = TypeAdapter.Adapt<SimpleDtoWithDefaultConstructor>(simplePoco);
 
@@ -30,7 +30,7 @@ namespace Mapster.Tests
         {
             TypeAdapterConfig<SimplePoco, SimpleDtoWithDefaultConstructor>.NewConfig()
                 .IgnoreNullValues(true)
-                .ConstructUsing(src => new SimpleDtoWithDefaultConstructor{Unmapped = "unmapped"})
+                .ConstructUsing(src => new SimpleDtoWithDefaultConstructor { Unmapped = "unmapped" })
                 .Compile();
 
             var simplePoco = new SimplePoco { Id = Guid.NewGuid(), Name = "TestName" };
@@ -47,7 +47,7 @@ namespace Mapster.Tests
         {
             TypeAdapterConfig<SimplePoco, ISimpleDtoWithDefaultConstructor>.NewConfig()
                 .IgnoreNullValues(true)
-                .ConstructUsing(src => new SimpleDtoWithDefaultConstructor {Unmapped = "unmapped"})
+                .ConstructUsing(src => new SimpleDtoWithDefaultConstructor { Unmapped = "unmapped" })
                 .Compile();
 
             var simplePoco = new SimplePoco { Id = Guid.NewGuid(), Name = "TestName" };
@@ -70,6 +70,20 @@ namespace Mapster.Tests
             dto.Id.ShouldBe(simplePoco.Id);
             dto.Name.ShouldBe(simplePoco.Name);
             dto.Unmapped.ShouldBe("unmapped");
+        }
+
+        [TestMethod]
+        public void Map_To_Destination_Type_Without_Default_Constructor_Shoud_Throw_Argument_Exception()
+        {
+            var simplePoco = new SimplePoco { Id = Guid.NewGuid(), Name = "TestName" };
+
+            Action action = () =>
+            {
+                var dto = TypeAdapter.Adapt<SimpleDtoWithoutDefaultConstructor>(simplePoco);
+            };
+
+            action.ShouldThrow<CompileException>()
+                .InnerException.ShouldBeOfType<ArgumentException>();
         }
 
         #region TestClasses
@@ -105,7 +119,7 @@ namespace Mapster.Tests
         }
 
         public class SimpleDtoWithoutDefaultConstructor
-        {       
+        {
 
             public SimpleDtoWithoutDefaultConstructor(string unmapped)
             {

--- a/src/Mapster/Adapters/BaseAdapter.cs
+++ b/src/Mapster/Adapters/BaseAdapter.cs
@@ -283,7 +283,7 @@ namespace Mapster.Adapters
                         typeof(InvalidOperationException).GetConstructor(new[] { typeof(string) }),
                         Expression.Constant("Cannot instantiate abstract type: " + arg.DestinationType.Name)),
                     arg.DestinationType);
-            else if (arg.DestinationType.HasDefaultConstructor())
+            else if (destination == null || arg.DestinationType.HasDefaultConstructor())
                 newObj = Expression.New(arg.DestinationType);
             else
                 newObj = destination;

--- a/src/Mapster/Adapters/BaseAdapter.cs
+++ b/src/Mapster/Adapters/BaseAdapter.cs
@@ -200,7 +200,7 @@ namespace Mapster.Adapters
                 //same type, no redirect to prevent endless loop
                 if (tuple.Source == arg.SourceType)
                     continue;
-                
+
                 //type is not compatible, no redirect
                 if (!arg.SourceType.IsReferenceAssignableFrom(tuple.Source))
                     continue;
@@ -242,7 +242,7 @@ namespace Mapster.Adapters
             }
 
             return Expression.Block(new[] { result }, set, result);
-        }
+        }       
         protected Expression CreateInlineExpressionBody(Expression source, CompileArgument arg)
         {
             //source == null ? default(TDestination) : adapt(source)
@@ -283,8 +283,10 @@ namespace Mapster.Adapters
                         typeof(InvalidOperationException).GetConstructor(new[] { typeof(string) }),
                         Expression.Constant("Cannot instantiate abstract type: " + arg.DestinationType.Name)),
                     arg.DestinationType);
-            else
+            else if (arg.DestinationType.HasDefaultConstructor())
                 newObj = Expression.New(arg.DestinationType);
+            else
+                newObj = destination;
 
             //dest ?? new TDest();
             return destination == null

--- a/src/Mapster/Extensions.cs
+++ b/src/Mapster/Extensions.cs
@@ -24,5 +24,16 @@ namespace Mapster
         {
             return (T)member.GetCustomAttributes(true).FirstOrDefault(attr => attr is T);
         }
+
+        /// <summary>
+        /// Determines whether the specific <paramref name="type"/> has default constructor.
+        /// </summary>
+        /// <param name="type">The type.</param>
+        /// <returns>
+        ///   <c>true</c> if specific <paramref name="type"/> has default constructor; otherwise <c>false</c>.
+        /// </returns>
+        public static bool HasDefaultConstructor(this Type type)
+            => type.IsValueType || type.GetConstructor(Type.EmptyTypes) != null;
+
     }
 }


### PR DESCRIPTION
This PR fixes #117. I tried investigate, why and when the problem was arose. Genesis of this is complicated. In commite 8c8d95e, condition (if destination is not null) was removed from method `CreateBlockExpressionBody` in `BaseAdapter` and `CreateInstantiationExpression` was called always. Where default constructor was calling. (what is incorrect when mapping to target instance without default constructor).

I tried this condition give to back, but tests for mapping to target instance failed.

So
I resolved it with condition for default constructor. If type doesn't have default constructor, destination expression is returning from `CreateInstantiationExpression` method.