### PR TITLE
if ToString method is null，Expression.Call throw exception

### DIFF
--- a/src/Mapster/Adapters/StringAdapter.cs
+++ b/src/Mapster/Adapters/StringAdapter.cs
@@ -18,6 +18,10 @@ namespace Mapster.Adapters
             if (destinationType == typeof(string))
             {
                 var method = source.Type.GetMethod("ToString", Type.EmptyTypes);
+                if (method == null)
+                {
+                    method = typeof(object).GetMethod("ToString", Type.EmptyTypes);
+                }
                 return Expression.Call(source, method);
             }
             else //if (sourceType == typeof(string))


### PR DESCRIPTION
if type is interface (eg: IEnumerable<int>), count not find ToString method