### PR TITLE
Support map directly to interface

### DIFF
--- a/src/Mapster.Tests/DynamicTypeGeneratorTests.cs
+++ b/src/Mapster.Tests/DynamicTypeGeneratorTests.cs
@@ -1,0 +1,114 @@
+﻿using Mapster.Utils;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Shouldly;
+using System;
+
+namespace Mapster.Tests
+{
+    [TestClass]
+    public class DynamicTypeGeneratorTests
+    {
+
+        private interface INotVisibleInterface
+        {
+            int Id { get; set; }
+            string Name { get; set; }
+        }
+
+        public interface ISimpleInterface
+        {
+            int Id { get; set; }
+            string Name { get; set; }
+        }
+
+        public interface IInheritedInterface : ISimpleInterface
+        {
+            int Value { get; set; }
+        }
+
+        public interface IComplexBaseInterface
+        {
+            int Id { get; set; }
+            void BaseMethod();
+        }
+
+        public interface IComplexInterface : IComplexBaseInterface
+        {
+            string Name { get; set; }
+            int ReadOnlyProp { get; }
+            int WriteOnlyProp { set; }
+            void SimpleMethod();
+            int ComplexMethod(byte b, ref int i, out string s);
+        }
+
+        [TestMethod]
+        public void ThrowExceptionWhenInterfaceIsNotVisible()
+        {
+            void action() => DynamicTypeGenerator.GetTypeForInterface(typeof(INotVisibleInterface));
+
+            var ex = Should.Throw<InvalidOperationException>(action);
+            ex.Message.ShouldContain("not accessible");
+        }
+
+        [TestMethod]
+        public void CreateTypeForSimpleInterface()
+        {
+            Type iClass = DynamicTypeGenerator.GetTypeForInterface(typeof(ISimpleInterface));
+
+            ISimpleInterface instance = (ISimpleInterface)Activator.CreateInstance(iClass);
+
+            instance.ShouldNotBeNull();
+            instance.ShouldBeAssignableTo<ISimpleInterface>();
+
+            instance.Id = 42;
+            instance.Name = "Lorem ipsum";
+
+            instance.Id.ShouldBe(42);
+            instance.Name.ShouldBe("Lorem ipsum");
+        }
+
+        [TestMethod]
+        public void CreateTypeForInheritedInterface()
+        {
+            Type iClass = DynamicTypeGenerator.GetTypeForInterface(typeof(IInheritedInterface));
+
+            IInheritedInterface instance = (IInheritedInterface)Activator.CreateInstance(iClass);
+
+            instance.ShouldNotBeNull();
+            instance.ShouldBeAssignableTo<IInheritedInterface>();
+
+            instance.Id = 42;
+            instance.Name = "Lorem ipsum";
+            instance.Value = 24;
+
+            instance.Id.ShouldBe(42);
+            instance.Name.ShouldBe("Lorem ipsum");
+            instance.Value.ShouldBe(24);
+        }
+
+        [TestMethod]
+        public void CreateTypeForComplexInterface()
+        {
+            Type iClass = DynamicTypeGenerator.GetTypeForInterface(typeof(IComplexInterface));
+
+            IComplexInterface instance = (IComplexInterface)Activator.CreateInstance(iClass);
+
+            instance.ShouldNotBeNull();
+            instance.ShouldBeAssignableTo<IComplexInterface>();
+
+            instance.Id = 42;
+            instance.Name = "Lorem ipsum";
+            instance.WriteOnlyProp = 24;
+
+            instance.Id.ShouldBe(42);
+            instance.Name.ShouldBe("Lorem ipsum");
+            instance.ReadOnlyProp.ShouldBe(0);
+
+            int i = 0;
+            string s = null;
+            Should.Throw<NotImplementedException>(() => instance.BaseMethod(), "Call BaseMethod.");
+            Should.Throw<NotImplementedException>(() => instance.SimpleMethod(), "Call SimpleMethod.");
+            Should.Throw<NotImplementedException>(() => instance.ComplexMethod(123, ref i, out s), "Call ComplexMethod.");
+        }
+    }
+}

--- a/src/Mapster.Tests/DynamicTypeGeneratorTests.cs
+++ b/src/Mapster.Tests/DynamicTypeGeneratorTests.cs
@@ -2,6 +2,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Shouldly;
 using System;
+using System.Collections.Generic;
 
 namespace Mapster.Tests
 {
@@ -25,17 +26,29 @@ namespace Mapster.Tests
             int Value { get; set; }
         }
 
+        public class Foo
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+        }
+
         public interface IComplexBaseInterface
         {
             int Id { get; set; }
+            Foo Foo { get; set; }
             void BaseMethod();
         }
 
         public interface IComplexInterface : IComplexBaseInterface
         {
             string Name { get; set; }
+            int? NullableInt { get; set; }
             int ReadOnlyProp { get; }
             int WriteOnlyProp { set; }
+            IEnumerable<int> Ints { get; set; }
+            IEnumerable<Foo> Foos { get; set; }
+            int[] IntArray { get; set; }
+            Foo[] FooArray { get; set; }
             void SimpleMethod();
             int ComplexMethod(byte b, ref int i, out string s);
         }
@@ -93,10 +106,18 @@ namespace Mapster.Tests
             instance.ShouldNotBeNull();
 
             instance.Id = 42;
+            instance.Foo = new Foo();
+            instance.NullableInt = 123;
             instance.Name = "Lorem ipsum";
             instance.WriteOnlyProp = 24;
+            instance.Ints = new List<int>();
+            instance.IntArray = new int[2];
+            instance.Foos = new List<Foo>();
+            instance.FooArray = new Foo[2];
 
             instance.Id.ShouldBe(42);
+            instance.Foo.ShouldNotBeNull();
+            instance.NullableInt.ShouldBe(123);
             instance.Name.ShouldBe("Lorem ipsum");
             instance.ReadOnlyProp.ShouldBe(0);
 

--- a/src/Mapster.Tests/DynamicTypeGeneratorTests.cs
+++ b/src/Mapster.Tests/DynamicTypeGeneratorTests.cs
@@ -8,7 +8,6 @@ namespace Mapster.Tests
     [TestClass]
     public class DynamicTypeGeneratorTests
     {
-
         private interface INotVisibleInterface
         {
             int Id { get; set; }
@@ -58,7 +57,6 @@ namespace Mapster.Tests
             ISimpleInterface instance = (ISimpleInterface)Activator.CreateInstance(iClass);
 
             instance.ShouldNotBeNull();
-            instance.ShouldBeAssignableTo<ISimpleInterface>();
 
             instance.Id = 42;
             instance.Name = "Lorem ipsum";
@@ -75,7 +73,6 @@ namespace Mapster.Tests
             IInheritedInterface instance = (IInheritedInterface)Activator.CreateInstance(iClass);
 
             instance.ShouldNotBeNull();
-            instance.ShouldBeAssignableTo<IInheritedInterface>();
 
             instance.Id = 42;
             instance.Name = "Lorem ipsum";
@@ -94,7 +91,6 @@ namespace Mapster.Tests
             IComplexInterface instance = (IComplexInterface)Activator.CreateInstance(iClass);
 
             instance.ShouldNotBeNull();
-            instance.ShouldBeAssignableTo<IComplexInterface>();
 
             instance.Id = 42;
             instance.Name = "Lorem ipsum";

--- a/src/Mapster.Tests/WhenMappingToInterface.cs
+++ b/src/Mapster.Tests/WhenMappingToInterface.cs
@@ -1,0 +1,127 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Shouldly;
+using System;
+
+namespace Mapster.Tests
+{
+    [TestClass]
+    public class WhenMappingToInterface
+    {
+        [TestInitialize]
+        public void Setup()
+        {
+            TypeAdapterConfig.GlobalSettings.Clear();
+        }
+
+        [TestMethod]
+        public void MapToInterface()
+        {
+            var dto = new Dto
+            {
+                Id = 1,
+                Name = "Test",
+                UnmappedSource = "Lorem ipsum"
+            };
+
+            IDto idto = dto.Adapt<IDto>();
+
+            idto.ShouldNotBeNull();
+            idto.Id.ShouldBe(dto.Id);
+            idto.Name.ShouldBe(dto.Name);
+            idto.UnmappedTarget.ShouldBeNull();
+        }
+
+        [TestMethod]
+        public void MapToInheritedInterface()
+        {
+            var dto = new InheritedDto
+            {
+                Id = 1,
+                Name = "Test",
+                DateOfBirth = new DateTime(1978, 12, 10),
+                UnmappedSource = "Lorem ipsum"
+            };
+
+            IInheritedDto idto = dto.Adapt<IInheritedDto>();
+
+            idto.ShouldNotBeNull();
+            idto.Id.ShouldBe(dto.Id);
+            idto.Name.ShouldBe(dto.Name);
+            idto.DateOfBirth.ShouldBe(dto.DateOfBirth);
+            idto.UnmappedTarget.ShouldBeNull();
+        }
+
+        [TestMethod]
+        public void MapToInterfaceWithMethods()
+        {
+            var dto = new Dto
+            {
+                Id = 1,
+                Name = "Test",
+                UnmappedSource = "Lorem ipsum"
+            };
+
+            IInterfaceWithMethods idto = dto.Adapt<IInterfaceWithMethods>();
+
+            idto.ShouldNotBeNull();
+            idto.Id.ShouldBe(dto.Id);
+            idto.Name.ShouldBe(dto.Name);
+            Should.Throw<NotImplementedException>(() => idto.DoSomething());
+        }
+
+        [TestMethod]
+        public void MapToNotVisibleInterfaceThrows()
+        {
+            var dto = new Dto
+            {
+                Id = 1,
+                Name = "Test",
+                UnmappedSource = "Lorem ipsum"
+            };
+
+            var ex = Should.Throw<CompileException>(() => dto.Adapt<INotVisibleInterface>());
+            ex.InnerException.ShouldBeOfType<InvalidOperationException>();
+            ex.InnerException.Message.ShouldContain("not accessible", "Correct InvalidOperationException must be thrown.");
+        }
+
+        private interface INotVisibleInterface
+        {
+            int Id { get; set; }
+            string Name { get; set; }
+        }
+
+        public interface IInterfaceWithMethods
+        {
+            int Id { get; set; }
+            string Name { get; set; }
+            void DoSomething();
+        }
+
+        public interface IDto
+        {
+            int Id { get; set; }
+            string Name { get; set; }
+            string UnmappedTarget { get; set; }
+        }
+
+        public interface IInheritedDto : IDto
+        {
+            DateTime DateOfBirth { get; set; }
+        }
+
+        public class Dto
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+            public string UnmappedSource { get; set; }
+        }
+
+        public class InheritedDto
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+            public DateTime DateOfBirth { get; set; }
+            public string UnmappedSource { get; set; }
+        }
+    }
+}

--- a/src/Mapster.Tests/WhenMappingToInterface.cs
+++ b/src/Mapster.Tests/WhenMappingToInterface.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Shouldly;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Mapster.Tests
 {
@@ -26,9 +28,11 @@ namespace Mapster.Tests
             IDto idto = dto.Adapt<IDto>();
 
             idto.ShouldNotBeNull();
-            idto.Id.ShouldBe(dto.Id);
-            idto.Name.ShouldBe(dto.Name);
-            idto.UnmappedTarget.ShouldBeNull();
+            idto.ShouldSatisfyAllConditions(
+                () => idto.Id.ShouldBe(dto.Id),
+                () => idto.Name.ShouldBe(dto.Name),
+                () => idto.UnmappedTarget.ShouldBeNull()
+            );
         }
 
         [TestMethod]
@@ -45,10 +49,82 @@ namespace Mapster.Tests
             IInheritedDto idto = dto.Adapt<IInheritedDto>();
 
             idto.ShouldNotBeNull();
-            idto.Id.ShouldBe(dto.Id);
-            idto.Name.ShouldBe(dto.Name);
-            idto.DateOfBirth.ShouldBe(dto.DateOfBirth);
-            idto.UnmappedTarget.ShouldBeNull();
+            idto.ShouldSatisfyAllConditions(
+                () => idto.Id.ShouldBe(dto.Id),
+                () => idto.Name.ShouldBe(dto.Name),
+                () => idto.DateOfBirth.ShouldBe(dto.DateOfBirth),
+                () => idto.UnmappedTarget.ShouldBeNull()
+            );
+        }
+
+        [TestMethod]
+        public void MapToComplexInterface()
+        {
+            var subItem = new ComplexDto
+            {
+                Name = "Inner lrem ipsum",
+                Int32 = 420,
+                Int64 = long.MaxValue,
+                NullInt1 = null,
+                NullInt2 = 240,
+                Floatn = 2.2F,
+                Doublen = 4.4,
+                DateTime = new DateTime(1978, 12, 10),
+                SubItem = null,
+                Dtos = new List<ComplexDto>(),
+                DtoArr = null,
+                Ints = new List<int>(),
+                IntArr = null
+            };
+
+            var dto = new ComplexDto
+            {
+                Name = "Lorem ipsum",
+                Int32 = 42,
+                Int64 = long.MaxValue,
+                NullInt1 = null,
+                NullInt2 = 24,
+                Floatn = 1.2F,
+                Doublen = 2.4,
+                DateTime = new DateTime(1978, 12, 10),
+                SubItem = subItem,
+                Dtos = new List<ComplexDto>(new[] { subItem, null }),
+                DtoArr = new ComplexDto[] { null, subItem },
+                Ints = new List<int>(new[] { 1, 2 }),
+                IntArr = new[] { 3, 4 }
+            };
+
+            IComplexInterface idto = dto.Adapt<IComplexInterface>();
+
+            idto.ShouldNotBeNull();
+            idto.ShouldSatisfyAllConditions(
+                () => idto.Name.ShouldBe(dto.Name),
+                () => idto.Int32.ShouldBe(dto.Int32),
+                () => idto.Int64.ShouldBe(dto.Int64),
+                () => idto.NullInt1.ShouldBeNull(),
+                () => idto.NullInt2.ShouldBe(dto.NullInt2),
+                () => idto.Floatn.ShouldBe(dto.Floatn),
+                () => idto.Doublen.ShouldBe(dto.Doublen),
+                () => idto.DateTime.ShouldBe(dto.DateTime)
+            );
+            idto.SubItem.ShouldSatisfyAllConditions(
+                () => idto.SubItem.Name.ShouldBe(dto.SubItem.Name),
+                () => idto.SubItem.Int32.ShouldBe(dto.SubItem.Int32),
+                () => idto.SubItem.Int64.ShouldBe(dto.SubItem.Int64),
+                () => idto.SubItem.NullInt1.ShouldBeNull(),
+                () => idto.SubItem.NullInt2.ShouldBe(dto.SubItem.NullInt2),
+                () => idto.SubItem.Floatn.ShouldBe(dto.SubItem.Floatn),
+                () => idto.SubItem.Doublen.ShouldBe(dto.SubItem.Doublen),
+                () => idto.SubItem.DateTime.ShouldBe(dto.SubItem.DateTime)
+            );
+            idto.ShouldSatisfyAllConditions(
+                () => idto.Dtos.Count().ShouldBe(dto.Dtos.Count()),
+                () => idto.DtoArr.Length.ShouldBe(dto.DtoArr.Length),
+                () => idto.Ints.First().ShouldBe(dto.Ints.First()),
+                () => idto.Ints.Last().ShouldBe(dto.Ints.Last()),
+                () => idto.IntArr[0].ShouldBe(dto.IntArr[0]),
+                () => idto.IntArr[1].ShouldBe(dto.IntArr[1])
+            );
         }
 
         [TestMethod]
@@ -64,9 +140,11 @@ namespace Mapster.Tests
             IInterfaceWithMethods idto = dto.Adapt<IInterfaceWithMethods>();
 
             idto.ShouldNotBeNull();
-            idto.Id.ShouldBe(dto.Id);
-            idto.Name.ShouldBe(dto.Name);
-            Should.Throw<NotImplementedException>(() => idto.DoSomething());
+            idto.ShouldSatisfyAllConditions(
+                () => idto.Id.ShouldBe(dto.Id),
+                () => idto.Name.ShouldBe(dto.Name),
+                () => Should.Throw<NotImplementedException>(() => idto.DoSomething())
+            );
         }
 
         [TestMethod]
@@ -122,6 +200,40 @@ namespace Mapster.Tests
             public string Name { get; set; }
             public DateTime DateOfBirth { get; set; }
             public string UnmappedSource { get; set; }
+        }
+
+        public interface IComplexInterface
+        {
+            string Name { get; set; }
+            int Int32 { get; set; }
+            long Int64 { get; set; }
+            int? NullInt1 { get; set; }
+            int? NullInt2 { get; set; }
+            float Floatn { get; set; }
+            double Doublen { get; set; }
+            DateTime DateTime { get; set; }
+            ComplexDto SubItem { get; set; }
+            IEnumerable<ComplexDto> Dtos { get; set; }
+            ComplexDto[] DtoArr { get; set; }
+            IEnumerable<int> Ints { get; set; }
+            int[] IntArr { get; set; }
+        }
+
+        public class ComplexDto
+        {
+            public string Name { get; set; }
+            public int Int32 { get; set; }
+            public long Int64 { set; get; }
+            public int? NullInt1 { get; set; }
+            public int? NullInt2 { get; set; }
+            public float Floatn { get; set; }
+            public double Doublen { get; set; }
+            public DateTime DateTime { get; set; }
+            public ComplexDto SubItem { get; set; }
+            public IEnumerable<ComplexDto> Dtos { get; set; }
+            public ComplexDto[] DtoArr { get; set; }
+            public IEnumerable<int> Ints { get; set; }
+            public int[] IntArr { get; set; }
         }
     }
 }

--- a/src/Mapster.Tests/WhenMappingToInterface.cs
+++ b/src/Mapster.Tests/WhenMappingToInterface.cs
@@ -36,7 +36,7 @@ namespace Mapster.Tests
         }
 
         [TestMethod]
-        public void MapToInheritedInterface()
+        public void MapToInheritedInterface_InterfaceHierarchyEnabled()
         {
             var dto = new InheritedDto
             {
@@ -46,7 +46,10 @@ namespace Mapster.Tests
                 UnmappedSource = "Lorem ipsum"
             };
 
-            IInheritedDto idto = dto.Adapt<IInheritedDto>();
+            var config = new TypeAdapterConfig();
+            config.Default.UseInterfaceHierarchy(true);
+
+            IInheritedDto idto = dto.Adapt<IInheritedDto>(config);
 
             idto.ShouldNotBeNull();
             idto.ShouldSatisfyAllConditions(
@@ -54,6 +57,79 @@ namespace Mapster.Tests
                 () => idto.Name.ShouldBe(dto.Name),
                 () => idto.DateOfBirth.ShouldBe(dto.DateOfBirth),
                 () => idto.UnmappedTarget.ShouldBeNull()
+            );
+        }
+
+        [TestMethod]
+        public void MapToInheritedInterface_InterfaceHierarchyDisabled()
+        {
+            var dto = new InheritedDto
+            {
+                Id = 1,
+                Name = "Test",
+                DateOfBirth = new DateTime(1978, 12, 10),
+                UnmappedSource = "Lorem ipsum"
+            };
+
+            var config = new TypeAdapterConfig();
+
+            IInheritedDto idto = dto.Adapt<IInheritedDto>(config);
+
+            idto.ShouldNotBeNull();
+            idto.ShouldSatisfyAllConditions(
+                () => idto.Id.ShouldBe(default),
+                () => idto.Name.ShouldBeNull(),
+                () => idto.DateOfBirth.ShouldBe(dto.DateOfBirth),
+                () => idto.UnmappedTarget.ShouldBeNull()
+            );
+        }
+
+        [TestMethod]
+        public void MapToInstanceWithInterface_InterfaceHierarchyEnabled()
+        {
+            var dto = new InheritedDto
+            {
+                Id = 1,
+                Name = "Test",
+                DateOfBirth = new DateTime(1978, 12, 10),
+                UnmappedSource = "Lorem ipsum"
+            };
+
+            var config = new TypeAdapterConfig();
+            config.Default.UseInterfaceHierarchy(true);
+
+            IInheritedDto target = new ImplementedDto();
+            dto.Adapt(target, config);
+
+            target.ShouldNotBeNull();
+            target.ShouldSatisfyAllConditions(
+                () => target.Id.ShouldBe(dto.Id),
+                () => target.Name.ShouldBe(dto.Name),
+                () => target.DateOfBirth.ShouldBe(dto.DateOfBirth),
+                () => target.UnmappedTarget.ShouldBeNull()
+            );
+        }
+
+        [TestMethod]
+        public void MapToInstanceWithInterface_InterfaceHierarchyDisabled()
+        {
+            var dto = new InheritedDto
+            {
+                Id = 1,
+                Name = "Test",
+                DateOfBirth = new DateTime(1978, 12, 10),
+                UnmappedSource = "Lorem ipsum"
+            };
+
+            IInheritedDto target = new ImplementedDto();
+            dto.Adapt(target);
+
+            target.ShouldNotBeNull();
+            target.ShouldSatisfyAllConditions(
+                () => target.Id.ShouldBe(default),
+                () => target.Name.ShouldBeNull(),
+                () => target.DateOfBirth.ShouldBe(dto.DateOfBirth),
+                () => target.UnmappedTarget.ShouldBeNull()
             );
         }
 
@@ -200,6 +276,14 @@ namespace Mapster.Tests
             public string Name { get; set; }
             public DateTime DateOfBirth { get; set; }
             public string UnmappedSource { get; set; }
+        }
+
+        public class ImplementedDto : IInheritedDto
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+            public DateTime DateOfBirth { get; set; }
+            public string UnmappedTarget { get; set; }
         }
 
         public interface IComplexInterface

--- a/src/Mapster/Adapters/BaseAdapter.cs
+++ b/src/Mapster/Adapters/BaseAdapter.cs
@@ -333,7 +333,11 @@ namespace Mapster.Adapters
             }
 
             //if mapping to interface, create dynamic type implementing it
+#if NETSTANDARD1_3
+            else if (destination is null && arg.DestinationType.IsInterface())
+#else
             else if (destination is null && arg.DestinationType.IsInterface)
+#endif
             {
                 return Expression.New(DynamicTypeGenerator.GetTypeForInterface(arg.DestinationType));
             }

--- a/src/Mapster/Adapters/BaseAdapter.cs
+++ b/src/Mapster/Adapters/BaseAdapter.cs
@@ -183,7 +183,7 @@ namespace Mapster.Adapters
                 {
                     var compareNull = Expression.Equal(source, Expression.Constant(null, source.Type));
                     blocks.Add(
-                        Expression.IfThen(compareNull, 
+                        Expression.IfThen(compareNull,
                             Expression.Return(label, arg.DestinationType.CreateDefault()))
                     );
                 }
@@ -250,7 +250,7 @@ namespace Mapster.Adapters
                     assignActions.Add(refAssign);
 
                     var usingBody = Expression.Block(
-                        new[] { cache, references, result }, 
+                        new[] { cache, references, result },
                         new Expression[] {assignReferences, setResult}
                             .Concat(assignActions)
                             .Concat(settingActions));
@@ -330,6 +330,12 @@ namespace Mapster.Adapters
                        typeof(InvalidOperationException).GetConstructor(new[] { typeof(string) }),
                        Expression.Constant("Cannot instantiate type: " + arg.DestinationType.Name)),
                    arg.DestinationType);
+            }
+
+            //if mapping to interface, create dynamic type implementing it
+            else if (destination is null && arg.DestinationType.IsInterface)
+            {
+                return Expression.New(DynamicTypeGenerator.GetTypeForInterface(arg.DestinationType));
             }
 
             //otherwise throw

--- a/src/Mapster/Adapters/BaseClassAdapter.cs
+++ b/src/Mapster/Adapters/BaseClassAdapter.cs
@@ -171,7 +171,7 @@ namespace Mapster.Adapters
         {
             return new ClassModel
             {
-                Members = arg.DestinationType.GetFieldsAndProperties(requireSetter: true, accessorFlags: BindingFlags.NonPublic | BindingFlags.Public)
+                Members = arg.DestinationType.GetFieldsAndProperties(useInterfaceHierarchy: arg.Settings.UseInterfaceHierarchy, requireSetter: true, accessorFlags: BindingFlags.NonPublic | BindingFlags.Public)
             };
         }
 

--- a/src/Mapster/Adapters/DictionaryAdapter.cs
+++ b/src/Mapster/Adapters/DictionaryAdapter.cs
@@ -26,7 +26,7 @@ namespace Mapster.Adapters
                 return false;
 
             //allow inline for dict-to-dict, only when IgnoreNonMapped
-            return arg.SourceType.GetDictionaryType() == null 
+            return arg.SourceType.GetDictionaryType() == null
                 || arg.Settings.IgnoreNonMapped == true;
         }
 
@@ -83,7 +83,7 @@ namespace Mapster.Adapters
                     dict.Add(ignore.Key, setWithCondition);
                 }
             }
-            
+
             //dict to switch
             if (dict.Count > 0 || ignores.Count > 0)
             {
@@ -175,7 +175,7 @@ namespace Mapster.Adapters
             if (arg.SourceType.GetDictionaryType() == null)
             {
                 var srcNames = arg.GetSourceNames();
-                var propNames = arg.SourceType.GetFieldsAndProperties(accessorFlags: BindingFlags.NonPublic | BindingFlags.Public)
+                var propNames = arg.SourceType.GetFieldsAndProperties(useInterfaceHierarchy: arg.Settings.UseInterfaceHierarchy, accessorFlags: BindingFlags.NonPublic | BindingFlags.Public)
                     .Where(model => model.ShouldMapMember(arg, MemberSide.Source))
                     .Select(model => model.Name)
                     .Where(name => !srcNames.Contains(name))

--- a/src/Mapster/Mapster.csproj
+++ b/src/Mapster/Mapster.csproj
@@ -4,7 +4,7 @@
         <Description>A fast, fun and stimulating object to object mapper.  Kind of like AutoMapper, just simpler and way, way faster.</Description>
         <Copyright>Copyright (c) 2016 Chaowlert Chaisrichalermpol, Eric Swann</Copyright>
         <Authors>chaowlert;eric_swann</Authors>
-        <TargetFrameworks>netstandard2.0;net45;net40</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;netstandard1.3;net45;net40</TargetFrameworks>
         <AssemblyName>Mapster</AssemblyName>
         <AssemblyOriginatorKeyFile>Mapster.snk</AssemblyOriginatorKeyFile>
         <SignAssembly>true</SignAssembly>

--- a/src/Mapster/Mapster.csproj
+++ b/src/Mapster/Mapster.csproj
@@ -4,7 +4,7 @@
         <Description>A fast, fun and stimulating object to object mapper.  Kind of like AutoMapper, just simpler and way, way faster.</Description>
         <Copyright>Copyright (c) 2016 Chaowlert Chaisrichalermpol, Eric Swann</Copyright>
         <Authors>chaowlert;eric_swann</Authors>
-        <TargetFrameworks>netstandard2.0;netstandard1.3;net45;net40</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;net45;net40</TargetFrameworks>
         <AssemblyName>Mapster</AssemblyName>
         <AssemblyOriginatorKeyFile>Mapster.snk</AssemblyOriginatorKeyFile>
         <SignAssembly>true</SignAssembly>
@@ -27,15 +27,18 @@
     </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
         <Reference Include="Microsoft.CSharp" />
+        <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
     </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
         <PackageReference Include="System.Collections.NonGeneric" Version="4.3.0" />
         <PackageReference Include="System.Linq.Queryable" Version="4.3.0" />
+        <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
         <PackageReference Include="System.Runtime" Version="4.3.0" />
         <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
         <PackageReference Include="System.Reflection.TypeExtensions" Version="4.5.1" />
     </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
         <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
+        <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
     </ItemGroup>
 </Project>

--- a/src/Mapster/Settings/ValueAccessingStrategy.cs
+++ b/src/Mapster/Settings/ValueAccessingStrategy.cs
@@ -75,7 +75,7 @@ namespace Mapster
 
         private static Expression? PropertyOrFieldFn(Expression source, IMemberModel destinationMember, CompileArgument arg)
         {
-            var members = source.Type.GetFieldsAndProperties(accessorFlags: BindingFlags.NonPublic | BindingFlags.Public);
+            var members = source.Type.GetFieldsAndProperties(useInterfaceHierarchy: arg.Settings.UseInterfaceHierarchy, accessorFlags: BindingFlags.NonPublic | BindingFlags.Public);
             var strategy = arg.Settings.NameMatchingStrategy;
             var destinationMemberName = destinationMember.GetMemberName(arg.Settings.GetMemberNames, strategy.DestinationMemberNameConverter);
             return members
@@ -110,7 +110,7 @@ namespace Mapster
         private static Expression? GetDeepFlattening(Expression source, string propertyName, CompileArgument arg)
         {
             var strategy = arg.Settings.NameMatchingStrategy;
-            var members = source.Type.GetFieldsAndProperties(accessorFlags: BindingFlags.NonPublic | BindingFlags.Public);
+            var members = source.Type.GetFieldsAndProperties(useInterfaceHierarchy: arg.Settings.UseInterfaceHierarchy, accessorFlags: BindingFlags.NonPublic | BindingFlags.Public);
             foreach (var member in members)
             {
                 if (!member.ShouldMapMember(arg, MemberSide.Source))
@@ -137,7 +137,7 @@ namespace Mapster
         {
             var strategy = arg.Settings.NameMatchingStrategy;
             var destinationMemberName = destinationMember.GetMemberName(arg.Settings.GetMemberNames, strategy.DestinationMemberNameConverter);
-            var members = source.Type.GetFieldsAndProperties(accessorFlags: BindingFlags.NonPublic | BindingFlags.Public);
+            var members = source.Type.GetFieldsAndProperties(useInterfaceHierarchy: arg.Settings.UseInterfaceHierarchy, accessorFlags: BindingFlags.NonPublic | BindingFlags.Public);
 
             foreach (var member in members)
             {
@@ -160,7 +160,7 @@ namespace Mapster
         private static IEnumerable<string> GetDeepUnflattening(IMemberModel destinationMember, string propertyName, CompileArgument arg)
         {
             var strategy = arg.Settings.NameMatchingStrategy;
-            var members = destinationMember.Type.GetFieldsAndProperties(accessorFlags: BindingFlags.NonPublic | BindingFlags.Public);
+            var members = destinationMember.Type.GetFieldsAndProperties(useInterfaceHierarchy: arg.Settings.UseInterfaceHierarchy, accessorFlags: BindingFlags.NonPublic | BindingFlags.Public);
             foreach (var member in members)
             {
                 if (!member.ShouldMapMember(arg, MemberSide.Destination))

--- a/src/Mapster/TypeAdapterSetter.cs
+++ b/src/Mapster/TypeAdapterSetter.cs
@@ -236,6 +236,14 @@ namespace Mapster
             setter.Settings.Unflattening = value;
             return setter;
         }
+
+        public static TSetter UseInterfaceHierarchy<TSetter>(this TSetter setter, bool value) where TSetter : TypeAdapterSetter
+        {
+            setter.CheckCompiled();
+
+            setter.Settings.UseInterfaceHierarchy = value;
+            return setter;
+        }
     }
 
     public class TypeAdapterSetter<TDestination> : TypeAdapterSetter
@@ -444,7 +452,7 @@ namespace Mapster
             Expression<Func<TSource, TSourceMember>> source, Expression<Func<TSource, bool>>? shouldMap = null)
         {
             this.CheckCompiled();
-            
+
             Settings.Resolvers.Add(new InvokerModel
             {
                 DestinationMemberName = memberName,
@@ -553,7 +561,7 @@ namespace Mapster
             return this;
         }
 
-        public TypeAdapterSetter<TSource, TDestination> Include<TDerivedSource, TDerivedDestination>() 
+        public TypeAdapterSetter<TSource, TDestination> Include<TDerivedSource, TDerivedDestination>()
             where TDerivedSource: class, TSource
             where TDerivedDestination: class, TDestination
         {
@@ -806,6 +814,13 @@ namespace Mapster
         {
             SourceToDestinationSetter.MaxDepth(value);
             DestinationToSourceSetter.MaxDepth(value);
+            return this;
+        }
+
+        public TwoWaysTypeAdapterSetter<TSource, TDestination> UseInterfaceHierarchy(bool value)
+        {
+            SourceToDestinationSetter.UseInterfaceHierarchy(value);
+            DestinationToSourceSetter.UseInterfaceHierarchy(value);
             return this;
         }
     }

--- a/src/Mapster/TypeAdapterSettings.cs
+++ b/src/Mapster/TypeAdapterSettings.cs
@@ -1,13 +1,11 @@
-﻿using System;
+﻿using Mapster.Models;
+using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
-using System.Reflection;
-using Mapster.Adapters;
-using Mapster.Models;
 
 namespace Mapster
 {
-    public class TypeAdapterSettings: SettingStore
+    public class TypeAdapterSettings : SettingStore
     {
         public IgnoreDictionary Ignore
         {
@@ -67,6 +65,12 @@ namespace Mapster
         {
             get => Get("SkipDestinationMemberCheck");
             set => Set("SkipDestinationMemberCheck", value);
+        }
+
+        public bool? UseInterfaceHierarchy
+        {
+            get => Get(nameof(UseInterfaceHierarchy));
+            set => Set(nameof(UseInterfaceHierarchy), value);
         }
 
         public List<Func<IMemberModel, MemberSide, bool?>> ShouldMapMember

--- a/src/Mapster/Utils/DynamicTypeGenerator.cs
+++ b/src/Mapster/Utils/DynamicTypeGenerator.cs
@@ -28,13 +28,21 @@ namespace Mapster.Utils
 
         private static void CheckInterfaceType(Type interfaceType)
         {
+#if NETSTANDARD1_3
+            if (!interfaceType.IsInterface())
+#else
             if (!interfaceType.IsInterface)
+#endif
             {
                 const string msg = "Cannot create dynamic type for {0}, because it is not an interface.\n" +
                     "Target type full name: {1}";
                 throw new InvalidOperationException(string.Format(msg, interfaceType.Name, interfaceType.FullName));
             }
+#if NETSTANDARD1_3
+            if (!interfaceType.IsVisible())
+#else
             if (!interfaceType.IsVisible)
+#endif
             {
                 const string msg = "Cannot adapt to interface {0}, because it is not accessible outside its assembly.\n" +
                     "Interface full name: {1}";
@@ -65,6 +73,8 @@ namespace Mapster.Utils
 
 #if NETSTANDARD2_0
             return builder.CreateTypeInfo();
+#elif NETSTANDARD1_3
+            return builder.CreateTypeInfo().AsType();
 #else
             return builder.CreateType();
 #endif

--- a/src/Mapster/Utils/DynamicTypeGenerator.cs
+++ b/src/Mapster/Utils/DynamicTypeGenerator.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Threading;
+
+namespace Mapster.Utils
+{
+    internal static class DynamicTypeGenerator
+    {
+        private const string DynamicAssemblyName = "MapsterGeneratedTypes";
+
+        private static readonly AssemblyBuilder _assemblyBuilder =
+#if NET40
+            AppDomain.CurrentDomain.DefineDynamicAssembly(new AssemblyName(DynamicAssemblyName), AssemblyBuilderAccess.Run);
+#else
+            AssemblyBuilder.DefineDynamicAssembly(new AssemblyName(DynamicAssemblyName), AssemblyBuilderAccess.Run);
+#endif
+        private static readonly ModuleBuilder _moduleBuilder = _assemblyBuilder.DefineDynamicModule("Classes");
+        private static readonly ConcurrentDictionary<Type, Type> _generated = new ConcurrentDictionary<Type, Type>();
+        private static int _generatedCounter = 0;
+
+        public static Type GetTypeForInterface(Type interfaceType)
+        {
+            CheckInterfaceType(interfaceType);
+            return _generated.GetOrAdd(interfaceType, (key) => CreateTypeForInterface(key));
+        }
+
+        private static void CheckInterfaceType(Type interfaceType)
+        {
+            if (!interfaceType.IsInterface)
+            {
+                const string msg = "Cannot create dynamic type for {0}, because it is not an interface.\n" +
+                    "Target type full name: {1}";
+                throw new InvalidOperationException(string.Format(msg, interfaceType.Name, interfaceType.FullName));
+            }
+            if (!interfaceType.IsVisible)
+            {
+                const string msg = "Cannot adapt to interface {0}, because it is not accessible outside its assembly.\n" +
+                    "Interface full name: {1}";
+                throw new InvalidOperationException(string.Format(msg, interfaceType.Name, interfaceType.FullName));
+            }
+        }
+
+        private static Type CreateTypeForInterface(Type interfaceType)
+        {
+            TypeBuilder builder = _moduleBuilder.DefineType("GeneratedType_" + Interlocked.Increment(ref _generatedCounter));
+            builder.AddInterfaceImplementation(interfaceType);
+
+            foreach (PropertyInfo prop in interfaceType.GetProperties())
+            {
+                CreateProperty(interfaceType, builder, prop);
+            }
+
+#if NETSTANDARD2_0
+            return builder.CreateTypeInfo();
+#else
+            return builder.CreateType();
+#endif
+        }
+
+        private static void CreateProperty(Type interfaceType, TypeBuilder builder, PropertyInfo prop)
+        {
+            const BindingFlags interfacePropMethodsFlags = BindingFlags.Instance | BindingFlags.Public;
+            // The property set and get methods require a special set of attributes.
+            const MethodAttributes classPropMethodAttrs
+                = MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.SpecialName | MethodAttributes.HideBySig;
+
+            FieldBuilder propField = builder.DefineField("_" + prop.Name, prop.PropertyType, FieldAttributes.Private);
+            PropertyBuilder propBuilder = builder.DefineProperty(prop.Name, PropertyAttributes.None, prop.PropertyType, null);
+
+            if (prop.CanRead)
+            {
+                // Define the "get" accessor method for property.
+                string getMethodName = "get_" + prop.Name;
+                MethodBuilder propGet = builder.DefineMethod(getMethodName, classPropMethodAttrs, prop.PropertyType, null);
+                ILGenerator propGetIL = propGet.GetILGenerator();
+                propGetIL.Emit(OpCodes.Ldarg_0);
+                propGetIL.Emit(OpCodes.Ldfld, propField);
+                propGetIL.Emit(OpCodes.Ret);
+
+                MethodInfo interfaceGetMethod = interfaceType.GetMethod(getMethodName, interfacePropMethodsFlags);
+                builder.DefineMethodOverride(propGet, interfaceGetMethod);
+                propBuilder.SetGetMethod(propGet);
+            }
+
+            if (prop.CanWrite)
+            {
+                // Define the "set" accessor method for property.
+                string setMethodName = "set_" + prop.Name;
+                MethodBuilder propSet = builder.DefineMethod(setMethodName, classPropMethodAttrs, null, new Type[] { prop.PropertyType });
+                ILGenerator propSetIL = propSet.GetILGenerator();
+                propSetIL.Emit(OpCodes.Ldarg_0);
+                propSetIL.Emit(OpCodes.Ldarg_1);
+                propSetIL.Emit(OpCodes.Stfld, propField);
+                propSetIL.Emit(OpCodes.Ret);
+
+                MethodInfo interfaceSetMethod = interfaceType.GetMethod(setMethodName, interfacePropMethodsFlags);
+                builder.DefineMethodOverride(propSet, interfaceSetMethod);
+                propBuilder.SetSetMethod(propSet);
+            }
+        }
+    }
+}

--- a/src/Mapster/Utils/DynamicTypeGenerator.cs
+++ b/src/Mapster/Utils/DynamicTypeGenerator.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Reflection;
 using System.Reflection.Emit;
 using System.Threading;
@@ -47,7 +46,7 @@ namespace Mapster.Utils
         {
             TypeBuilder builder = _moduleBuilder.DefineType("GeneratedType_" + Interlocked.Increment(ref _generatedCounter));
 
-            foreach (Type currentInterface in GetAllInterfaces(interfaceType))
+            foreach (Type currentInterface in ReflectionUtils.GetAllInterfaces(interfaceType))
             {
                 builder.AddInterfaceImplementation(currentInterface);
                 foreach (PropertyInfo prop in currentInterface.GetProperties())
@@ -69,30 +68,6 @@ namespace Mapster.Utils
 #else
             return builder.CreateType();
 #endif
-        }
-
-        // GetProperties() and GetMethods() do not return properties/methods from parent interfaces,
-        // so we need to process every one of them.
-        private static IEnumerable<Type> GetAllInterfaces(Type interfaceType)
-        {
-            var allInterfaces = new List<Type>();
-            var interfaceQueue = new Queue<Type>();
-            allInterfaces.Add(interfaceType);
-            interfaceQueue.Enqueue(interfaceType);
-            while (interfaceQueue.Count > 0)
-            {
-                var currentInterface = interfaceQueue.Dequeue();
-                foreach (var subInterface in currentInterface.GetInterfaces())
-                {
-                    if (allInterfaces.Contains(subInterface))
-                    {
-                        continue;
-                    }
-                    allInterfaces.Add(subInterface);
-                    interfaceQueue.Enqueue(subInterface);
-                }
-            }
-            return allInterfaces;
         }
 
         private static void CreateProperty(Type interfaceType, TypeBuilder builder, PropertyInfo prop)

--- a/src/Mapster/Utils/ReflectionUtils.cs
+++ b/src/Mapster/Utils/ReflectionUtils.cs
@@ -79,10 +79,14 @@ namespace Mapster
             if (type.IsConvertible())
                 return false;
 
-            return type.GetFieldsAndProperties(requireSetter: true).Any();
+            return type.GetFieldsAndProperties(useInterfaceHierarchy: true, requireSetter: true).Any();
         }
 
-        public static IEnumerable<IMemberModelEx> GetFieldsAndProperties(this Type type, bool requireSetter = false, BindingFlags accessorFlags = BindingFlags.Public)
+        public static IEnumerable<IMemberModelEx> GetFieldsAndProperties(
+            this Type type,
+            bool? useInterfaceHierarchy,
+            bool requireSetter = false,
+            BindingFlags accessorFlags = BindingFlags.Public)
         {
             var bindingFlags = BindingFlags.Instance | accessorFlags;
 
@@ -99,9 +103,9 @@ namespace Mapster
             IEnumerable<IMemberModelEx> fields;
 
 #if NETSTANDARD1_3
-            if (type.IsInterface())
+            if (type.IsInterface() && (useInterfaceHierarchy == true))
 #else
-            if (type.IsInterface)
+            if (type.IsInterface && (useInterfaceHierarchy == true))
 #endif
             {
                 IEnumerable<Type> allInterfaces = GetAllInterfaces(type);
@@ -232,7 +236,7 @@ namespace Mapster
                 return false;
 
             //no public setter
-            var props = type.GetFieldsAndProperties().ToList();
+            var props = type.GetFieldsAndProperties(useInterfaceHierarchy: true).ToList();
             if (props.Any(p => p.SetterModifier == AccessModifier.Public))
                 return false;
 

--- a/src/Mapster/Utils/ReflectionUtils.cs
+++ b/src/Mapster/Utils/ReflectionUtils.cs
@@ -55,6 +55,8 @@ namespace Mapster
         {
             return member.CustomAttributes;
         }
+        public static bool IsInterface(this Type type) => type.GetTypeInfo().IsInterface;
+        public static bool IsVisible(this Type type) => type.GetTypeInfo().IsVisible;
 #endif
 
         public static bool IsNullable(this Type type)
@@ -96,7 +98,11 @@ namespace Mapster
             IEnumerable<IMemberModelEx> properties;
             IEnumerable<IMemberModelEx> fields;
 
+#if NETSTANDARD1_3
+            if (type.IsInterface())
+#else
             if (type.IsInterface)
+#endif
             {
                 IEnumerable<Type> allInterfaces = GetAllInterfaces(type);
                 properties = allInterfaces.SelectMany(currentInterface => getPropertiesFunc(currentInterface));


### PR DESCRIPTION
Closes #220 
Closes #188 

With this changes, Mapster is able to map directly fo interface, without needing the class.

- Mapster will create the class (type) dynamically for every interface it is mapping to. The class is created only once and cached.
- Although the intended use case are simple interfaces with properties only, it supports even interfaces with methods. Calling methods in generated class wil just throw `NotImplementedException`.
- Generics are not supported.
- Indexed properties are not supported.

This (when turned on) will fix the issue #188.

Mapping to interfaces which are not inherited, works out-of-the-box. If interface is inherited, the default behavior stays the same as now - only the properties owned by targe interface are mapped. To map properties from parent interface(s), the setting `UseInterfaceHierarchy` must be enabled.

``` csharp
TypeAdapterConfig.GlobalSettings.Default.UseInterfaceHierarchy(true);
```

The setting can be used as any other setting for specific mapping only.

Personally, I was surprised by this behavior with inherited interfaces. I would expect that all the properties up the hierarchy just work. And so I would prefer default value of `UseInterfaceHierarchy` to be `true`. But this could introduce breaking change for some scenarions.