### PR TITLE
Fix property name match when using AdaptMember Attribute

### DIFF
--- a/src/Mapster.Tests/WhenUsingAttributeWithNameMatchingStrategy.cs
+++ b/src/Mapster.Tests/WhenUsingAttributeWithNameMatchingStrategy.cs
@@ -1,0 +1,45 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Mapster.Tests
+{
+    [TestClass]
+    public class WhenUsingAttributeWithNameMatchingStrategy
+    {
+        [TestMethod]
+        public void Using_Attributes_With_NameMatchingStrategy()
+        {
+            TypeAdapterConfig.GlobalSettings.Default.NameMatchingStrategy(NameMatchingStrategy.IgnoreCase);
+
+            var id = Guid.NewGuid();
+            var poco = new SimplePoco(id) { Name = "test" };
+            var dto = poco.Adapt<SimpleDto>();
+            dto.IdCode.ShouldBe(id);
+            dto.Name.ShouldBeNull();
+        }
+
+        public class SimplePoco
+        {
+            public SimplePoco(Guid id) { this.id = id; }
+
+            [AdaptMember("IdCode")]
+            private Guid id { get; }
+
+            [AdaptIgnore]
+            public string Name { get; set; }
+        }
+
+        public class SimpleDto
+        {
+            public Guid IdCode { get; set; }
+            public string Name { get; set; }
+        }
+
+
+    }
+}

--- a/src/Mapster/Utils/ReflectionUtils.cs
+++ b/src/Mapster/Utils/ReflectionUtils.cs
@@ -333,9 +333,11 @@ namespace Mapster
 
         public static string GetMemberName(this IMemberModel member, List<Func<IMemberModel, string?>> getMemberNames, Func<string, string> nameConverter)
         {
-            return getMemberNames.Select(predicate => predicate(member))
+            var memberName = getMemberNames.Select(predicate => predicate(member))
                 .FirstOrDefault(name => name != null)
-                ?? nameConverter(member.Name);
+                ?? member.Name;
+
+            return nameConverter(memberName);
         }
 
         public static bool IsPrimitiveKind(this Type type)


### PR DESCRIPTION
Hi!

This is my first PR. This is supposed to fix: #240 

I had to create a new class to make the test fail. 

If this test runs together with the test on WhenUsingAttribute it wont faild. Maybe because the NameMatchingStrategy setting has no effect after a "Adapt" has ran.

PS: Sorry if my English writing has some mistakes.