### PR TITLE
Add ability to compile all mappings and then throw AggregateException

### DIFF
--- a/src/Mapster/TypeAdapterConfig.cs
+++ b/src/Mapster/TypeAdapterConfig.cs
@@ -575,15 +575,35 @@ namespace Mapster
             };
         }
 
-        public void Compile()
+        public void Compile(bool failFast = true)
         {
+            var exceptions = new List<Exception>();
             var keys = RuleMap.Keys.ToList();
+
             foreach (var key in keys)
             {
-                if (key.Source == typeof(void))
-                    continue;
-                _mapDict[key] = Compiler(CreateMapExpression(key, MapType.Map));
-                _mapToTargetDict[key] = Compiler(CreateMapExpression(key, MapType.MapToTarget));
+                try
+                {
+                    if (key.Source == typeof(void))
+                        continue;
+
+                    _mapDict[key] = Compiler(CreateMapExpression(key, MapType.Map));
+                    _mapToTargetDict[key] = Compiler(CreateMapExpression(key, MapType.MapToTarget));
+                }
+                catch (Exception ex)
+                {
+                    if (failFast)
+                    {
+                        throw;
+                    }
+
+                    exceptions.Add(ex);
+                }
+            }
+
+            if (exceptions.Count > 0)
+            {
+                throw new AggregateException(exceptions);
             }
         }
 


### PR DESCRIPTION
Hi, guys. We would like to have ability try to compile all mapping configurations in solution and only then fail if something is wrong. We are going to add call Compile method in startup time. Currently, I see only first incorrect mapping configuration and I have to start my solution each time to discover only 1 problem. With this change, I just need to start up my project only one time to get all mapping errors. 
@chaowlert 