### PR TITLE
Init read-only properties when mapping with a non-readonly interface fixes #374

### DIFF
--- a/src/Mapster.Tests/WhenMappingToInterface.cs
+++ b/src/Mapster.Tests/WhenMappingToInterface.cs
@@ -235,6 +235,32 @@ namespace Mapster.Tests
             idto.UnmappedSource.ShouldBeNull();
         }
 
+        [TestMethod]
+        public void MappingToInterfaceWithWritableProps()
+        {
+            var source = new PropertyInitializationTestSource { Property1 = 42, Property2 = 43 };
+            var target = source.Adapt<IInterfaceWithWritableProperties>();
+
+            target.ShouldNotBeNull();
+            target.ShouldSatisfyAllConditions(
+                () => target.Property1.ShouldBe(source.Property1),
+                () => target.Property2.ShouldBe(source.Property2)
+            );
+        }
+
+        [TestMethod]
+        public void MappingToInteraceWithReadonlyProps_AllPropsInitialized()
+        {
+            var source = new PropertyInitializationTestSource { Property1 = 42, Property2 = 43 };
+            var target = source.Adapt<IReadonlyInterface>();
+
+            target.ShouldNotBeNull();
+            target.ShouldSatisfyAllConditions(
+                () => target.Property1.ShouldBe(source.Property1),
+                () => target.Property2.ShouldBe(source.Property2)
+            );
+        }
+
         public interface IInheritedDtoWithoutProperties : IInheritedDto
         {
         }
@@ -325,5 +351,24 @@ namespace Mapster.Tests
             public IEnumerable<int> Ints { get; set; }
             public int[] IntArr { get; set; }
         }
+
+        public interface IReadonlyInterface
+        {
+            int Property1 { get; }
+            int Property2 { get; }
+        }
+
+        public interface IInterfaceWithWritableProperties
+        {
+            int Property1 { get; set; }
+            int Property2 { get; }
+        }
+
+        public class PropertyInitializationTestSource
+        {
+            public int Property1 { get; set; }
+            public int Property2 { get; set; }
+        }
+
     }
 }

--- a/src/Mapster/Utils/DynamicTypeGenerator.cs
+++ b/src/Mapster/Utils/DynamicTypeGenerator.cs
@@ -58,6 +58,8 @@ namespace Mapster.Utils
 
             var args = new List<FieldBuilder>();
             int propCount = 0;
+            var hasReadonlyProps = false;
+
             foreach (Type currentInterface in interfaceType.GetAllInterfaces())
             {
                 builder.AddInterfaceImplementation(currentInterface);
@@ -66,8 +68,8 @@ namespace Mapster.Utils
                     propCount++;
                     FieldBuilder propField = builder.DefineField("_" + MapsterHelper.CamelCase(prop.Name), prop.PropertyType, FieldAttributes.Private);
                     CreateProperty(currentInterface, builder, prop, propField);
-                    if (!prop.CanWrite)
-                        args.Add(propField);
+                    if (!prop.CanWrite) hasReadonlyProps = true;
+                    args.Add(propField);
                 }
                 foreach (MethodInfo method in currentInterface.GetMethods())
                 {
@@ -82,7 +84,7 @@ namespace Mapster.Utils
             if (propCount == 0)
                 throw new InvalidOperationException($"No default constructor for type '{interfaceType.Name}', please use 'ConstructUsing' or 'MapWith'");
 
-            if (args.Count == propCount)
+            if (hasReadonlyProps)
             {
                 var ctorBuilder = builder.DefineConstructor(MethodAttributes.Public, 
                     CallingConventions.Standard,

--- a/src/Mapster/Utils/ReflectionUtils.cs
+++ b/src/Mapster/Utils/ReflectionUtils.cs
@@ -170,9 +170,9 @@ namespace Mapster
 
             var props = type.GetFieldsAndProperties().ToList();
 
-            //interface, all props must be readonly
+            //interface with readonly props
             if (type.GetTypeInfo().IsInterface && 
-                props.All(p => p.SetterModifier != AccessModifier.Public))
+                props.Any(p => p.SetterModifier != AccessModifier.Public))
                 return true;
 
             //1 constructor


### PR DESCRIPTION
Enable `source.Adapt<ITarget>()` always to initialize all properties of the autogenerated class from source (including readonly ones) fixes #374 