### PR TITLE
Added support for internal constructors that are accessible via InternalsVisibleToAttribute

### DIFF
--- a/src/Mapster.Tests.InternalsVisibleAssembly/DtoStubs.cs
+++ b/src/Mapster.Tests.InternalsVisibleAssembly/DtoStubs.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+
+//Expose this to Mapster.Tests
+[assembly: InternalsVisibleTo("Mapster.Tests")]
+
+namespace Mapster.Tests.InternalsVisibleAssembly
+{
+    public class DtoInternal
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; }
+        public int Age { get; } = -1;
+        public string Prop { get; set; }
+        public string OtherProp { get; set; }
+
+        internal DtoInternal() { }
+    }    
+
+    public class DtoPrivate
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; }
+        public int Age { get; } = -1;
+        public string Prop { get; set; }
+
+        private DtoPrivate() { }
+    }
+}
+

--- a/src/Mapster.Tests.InternalsVisibleAssembly/Mapster.Tests.InternalsVisibleAssembly.csproj
+++ b/src/Mapster.Tests.InternalsVisibleAssembly/Mapster.Tests.InternalsVisibleAssembly.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/src/Mapster.Tests/Mapster.Tests.csproj
+++ b/src/Mapster.Tests/Mapster.Tests.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>netcoreapp2.0</TargetFramework>
+        <TargetFramework>netcoreapp2.1</TargetFramework>
         <IsPackable>false</IsPackable>
         <AssemblyName>Mapster.Tests</AssemblyName>
         <AssemblyOriginatorKeyFile>Mapster.Tests.snk</AssemblyOriginatorKeyFile>
@@ -19,6 +19,7 @@
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\Mapster\Mapster.csproj" />
+        <ProjectReference Include="..\Mapster.Tests.InternalsVisibleAssembly\Mapster.Tests.InternalsVisibleAssembly.csproj" />
     </ItemGroup>
     <ItemGroup>
       <None Remove="packages.config" />

--- a/src/Mapster.Tests/WhenMappingInternalConstructor.cs
+++ b/src/Mapster.Tests/WhenMappingInternalConstructor.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Shouldly;
+using Mapster.Tests.InternalsVisibleAssembly;
+using System;
+
+namespace Mapster.Tests
+{
+    [TestClass]
+    public class WhenMappingInternalConstructor
+    {
+       
+        [TestMethod]
+        public void MapToConstructor_InternalVisible()
+        {             
+            var poco = new Poco { Id = Guid.NewGuid(), Name = "Test", Prop = "Prop", OtherProp = "OtherProp" };
+            var dto = TypeAdapter.Adapt<DtoInternal>(poco);
+
+            dto.Id.ShouldBe(poco.Id);
+            dto.Name.ShouldBe(poco.Name);
+            dto.Age.ShouldBe(-1);
+            dto.Prop.ShouldBe(poco.Prop);
+        }
+      
+
+        [TestMethod]
+        public void MapToConstructor_PrivateVisible_ShouldThrow()
+        {            
+            var poco = new Poco { Id = Guid.NewGuid(), Name = "Test", Prop = "Prop", OtherProp = "OtherProp" };
+            var ex = Assert.ThrowsException<CompileException>(() => poco.Adapt<DtoPrivate>());
+            Assert.IsInstanceOfType(ex.InnerException, typeof(InvalidOperationException));
+            Assert.IsTrue(ex.InnerException.Message.Contains("No default constructor for type"));
+        }
+
+        public class Poco
+        {
+            public Guid Id { get; set; }
+            public string Name { get; set; }
+            public string Prop { get; set; }
+            public string OtherProp { get; set; }
+        }       
+    }
+}

--- a/src/Mapster.sln
+++ b/src/Mapster.sln
@@ -55,6 +55,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mapster.SourceGenerator", "
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mapster.Core", "Mapster.Core\Mapster.Core.csproj", "{1A7D2FD4-DDEC-4E11-93FF-1310F34F67CF}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mapster.Tests.InternalsVisibleAssembly", "Mapster.Tests.InternalsVisibleAssembly\Mapster.Tests.InternalsVisibleAssembly.csproj", "{927CC36B-F45C-4B6E-A55D-D162D06570BD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -137,6 +139,10 @@ Global
 		{1A7D2FD4-DDEC-4E11-93FF-1310F34F67CF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1A7D2FD4-DDEC-4E11-93FF-1310F34F67CF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1A7D2FD4-DDEC-4E11-93FF-1310F34F67CF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{927CC36B-F45C-4B6E-A55D-D162D06570BD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{927CC36B-F45C-4B6E-A55D-D162D06570BD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{927CC36B-F45C-4B6E-A55D-D162D06570BD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{927CC36B-F45C-4B6E-A55D-D162D06570BD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -156,6 +162,7 @@ Global
 		{DE045991-6268-46EE-B5D3-79DE75820976} = {916FA044-B9E5-44F2-991A-85AA43C08255}
 		{D5DF0FB7-44A5-4326-9EC4-5B8F7FCCE00F} = {D33E5A90-ABCA-4B2D-8758-2873CC5AB847}
 		{3CB56440-5449-4DE5-A8D3-549C87C1B36A} = {EF7E343F-592E-4EAC-A0A4-92EB4B95CB89}
+		{927CC36B-F45C-4B6E-A55D-D162D06570BD} = {D33E5A90-ABCA-4B2D-8758-2873CC5AB847}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {83B87DBA-277C-49F1-B597-E3B78C2C8275}


### PR DESCRIPTION
Added support for detecting internal default constructors in the source assembly that are accessible to the destination assembly via the InternalsVisibleToAttribute.  I have not ran the tests in net1_3.  I updated the tests project to target netcoreapp2.1 as otherwise my tests would not run, despite installing the 2.0 SDK.