### PR TITLE
Include .NET 6.0 as Target Framework for Mapster.Tool

### DIFF
--- a/src/Mapster.Tool/Mapster.Tool.csproj
+++ b/src/Mapster.Tool/Mapster.Tool.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-mapster</ToolCommandName>


### PR DESCRIPTION
Resolves #381