### PR TITLE
Add net6.0 as TargetFramework for Mapster.Tool

### DIFF
--- a/src/Mapster.Tool/Mapster.Tool.csproj
+++ b/src/Mapster.Tool/Mapster.Tool.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-mapster</ToolCommandName>


### PR DESCRIPTION
This is a shameful copy of the #390, which unfortunately hasn't been merged for 9 days following its approval.

This has been preventing our team to upgrade to .NET 6, hence this PR.