### PR TITLE
Added IOrderedQueryable Interface on MapsterQueryable 

### DIFF
--- a/src/Mapster.EFCore/MapsterQueryable.cs
+++ b/src/Mapster.EFCore/MapsterQueryable.cs
@@ -25,7 +25,7 @@ namespace Mapster.EFCore
         public Expression Expression => _queryable.Expression;
         public IQueryProvider Provider { get; }
     }
-    class MapsterQueryable<T> : MapsterQueryable, IQueryable<T>, IAsyncEnumerable<T>
+    class MapsterQueryable<T> : MapsterQueryable, IQueryable<T>, IAsyncEnumerable<T>, IOrderedQueryable<T>
     {
         public MapsterQueryable(IQueryable<T> queryable, IAdapterBuilder builder) : 
             base(queryable, builder) { }


### PR DESCRIPTION
I'm currently using Mapster as mapping tool for OData in order to optimize my sql queries with entity framework and avoid exposing the DAL :)

But when I'm using new Mapper().From(IQueryable<T> query).ProjectTo<U>(); I can't OrderBy the result of the projection, it says can't cast MapsterQueryable<U> to IOrderedQueryable<U>.

So I've added the interface and one unit test to ensure it's possible now. 
Regards.