### PR TITLE
Support ConstructUsing in CollectionAdapter

### DIFF
--- a/src/Mapster.Tests/WhenMappingCollections.cs
+++ b/src/Mapster.Tests/WhenMappingCollections.cs
@@ -294,6 +294,19 @@ namespace Mapster.Tests
             }
         }
 
+        [TestMethod]
+        public void RespectConstructUsing()
+        {
+            var source = new List<int> { 1, 1, 3, };
+
+            var result = source
+                .BuildAdapter()
+                .ForkConfig(x => x.ForDestinationType<ICollection<string>>().ConstructUsing(() => new HashSet<string>()))
+                .AdaptToType<ICollection<string>>();
+
+            result.ShouldBe(new List<string> { "1", "3", });
+        }
+
         #region TestClass
 
         [Flags]

--- a/src/Mapster/Adapters/CollectionAdapter.cs
+++ b/src/Mapster/Adapters/CollectionAdapter.cs
@@ -44,6 +44,13 @@ namespace Mapster.Adapters
 
         protected override Expression CreateInstantiationExpression(Expression source, Expression? destination, CompileArgument arg)
         {
+            //if there is constructUsing, use constructUsing
+            var constructUsing = arg.GetConstructUsing();
+            if (constructUsing != null)
+            {
+                return base.CreateInstantiationExpression(source, destination, arg);
+            }
+
             var listType = arg.DestinationType;
             if (arg.DestinationType.GetTypeInfo().IsInterface)
             {


### PR DESCRIPTION
I think the CollectionAdapter should respect ConstructUsing so the user can control how the collection is instantiated.