### PR TITLE
Add destination parameter to before and after mapping delegates

### DIFF
--- a/src/Mapster.Tests/WhenMappingToTarget.cs
+++ b/src/Mapster.Tests/WhenMappingToTarget.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Linq.Expressions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Shouldly;
 
@@ -11,12 +10,23 @@ namespace Mapster.Tests
         [TestMethod]
         public void MappingToTarget_With_SameList()
         {
-            var a = new Foo { A = 1, List = new List<int> {1,2,3} };
-            var b = new Bar { A = 2, List = a.List};
+            var a = new Foo { A = 1, List = new List<int> { 1, 2, 3 } };
+            var b = new Bar { A = 2, List = a.List };
 
             a.Adapt(b);
+
             b.A.ShouldBe(1);
-            b.List.ShouldBe(new List<int>{1,2,3});
+            b.List.ShouldBe(new List<int> { 1, 2, 3 });
+        }
+
+        [TestMethod]
+        public void MappingToTarget_With_NullDestinationList_Create_New()
+        {
+            var a = new Foo { List = new List<int> { 1, 2, 3, } };
+            var b = new Bar { List = null };
+
+            a.Adapt(b);
+            b.List.ShouldBe(new List<int> { 1, 2, 3, });
         }
 
         public class Foo

--- a/src/Mapster.Tests/WhenPerformingAfterMapping.cs
+++ b/src/Mapster.Tests/WhenPerformingAfterMapping.cs
@@ -46,7 +46,6 @@ namespace Mapster.Tests
             result.IsValidated.ShouldBeTrue();
         }
 
-
         [TestMethod]
         public void No_Compile_Error_When_ConstructUsing_ForDestinationType()
         {
@@ -55,6 +54,41 @@ namespace Mapster.Tests
             TypeAdapterConfig.GlobalSettings.Compile();
         }
 
+        [TestMethod]
+        public void MapToType_Support_Destination_Parameter()
+        {
+            TypeAdapterConfig<SimplePoco, SimpleDto>.NewConfig()
+                .AfterMapping((src, result, destination) => result.Name += $"{destination.Name}xxx");
+
+            var poco = new SimplePoco
+            {
+                Id = Guid.NewGuid(),
+                Name = "test",
+            };
+
+            // check expression is successfully compiled
+            Assert.ThrowsException<NullReferenceException>(() => poco.Adapt<SimpleDto>());
+        }
+
+        [TestMethod]
+        public void MapToTarget_Support_Destination_Parameter()
+        {
+            TypeAdapterConfig<SimplePoco, SimpleDto>.NewConfig()
+                .ConstructUsing((simplePoco, dto) => new SimpleDto())
+                .AfterMapping((src, result, destination) => result.Name += $"{destination.Name}xxx");
+
+            var poco = new SimplePoco
+            {
+                Id = Guid.NewGuid(),
+                Name = "test",
+            };
+            var oldDto = new SimpleDto { Name = "zzz", };
+            var result = poco.Adapt(oldDto);
+
+            result.ShouldNotBeSameAs(oldDto);
+            result.Id.ShouldBe(poco.Id);
+            result.Name.ShouldBe(poco.Name + "zzzxxx");
+        }
 
         public interface IValidatable
         {

--- a/src/Mapster.Tests/WhenPerformingBeforeMapping.cs
+++ b/src/Mapster.Tests/WhenPerformingBeforeMapping.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Shouldly;
+
+namespace Mapster.Tests
+{
+    [TestClass]
+    public class WhenPerformingBeforeMapping
+    {
+        [TestCleanup]
+        public void TestCleanup()
+        {
+            TypeAdapterConfig.GlobalSettings.Clear();
+        }
+
+        [TestMethod]
+        public void MapToType_Support_Destination_Parameter()
+        {
+            TypeAdapterConfig<SimplePoco, SimpleDto>.NewConfig()
+                .BeforeMapping((src, result, destination) => result.Name += $"{destination.Name}xxx");
+
+            var poco = new SimplePoco
+            {
+                Id = Guid.NewGuid(),
+                Name = "test",
+            };
+            
+            // check expression is successfully compiled
+            Assert.ThrowsException<NullReferenceException>(() => poco.Adapt<SimpleDto>());
+        }
+
+        [TestMethod]
+        public void MapToTarget_Support_Destination_Parameter()
+        {
+            TypeAdapterConfig<IEnumerable<int>, IEnumerable<int>>.NewConfig()
+                .BeforeMapping((src, result, destination) =>
+                {
+                    if (!ReferenceEquals(result, destination) && destination != null && result is ICollection<int> resultCollection)
+                    {
+                        foreach (var item in destination)
+                        {
+                            resultCollection.Add(item);
+                        }
+                    }
+                });
+
+            IEnumerable<int> source = new List<int> { 1, 2, 3, };
+            IEnumerable<int> destination = new List<int> { 0, };
+
+            var result = source.Adapt(destination);
+
+            destination.ShouldBe(new List<int> { 0, });
+            source.ShouldBe(new List<int> { 1, 2, 3, });
+            result.ShouldBe(new List<int> { 0, 1, 2, 3, });
+        }
+
+        public class SimplePoco
+        {
+            public Guid Id { get; set; }
+            public string Name { get; set; }
+        }
+
+        public class SimpleDto
+        {
+            public Guid Id { get; set; }
+            public string Name { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
I have noticed that the result object is different from the destination but I have no way to do anything about it. So I thought it would be useful to pass the destination parameter to (before|after)mapping delegates.
It could help with cases like #430 