### PR TITLE
Removed directory separator character and use Path.DirectorySeparatorChar instead

### DIFF
--- a/src/Mapster.Tool/Program.cs
+++ b/src/Mapster.Tool/Program.cs
@@ -39,7 +39,7 @@ namespace Mapster.Tool
             var fullBasePath = Path.GetFullPath(baseOutput);
             return segment == null 
                 ? Path.Combine(fullBasePath, typeName + ".g.cs") 
-                : Path.Combine(fullBasePath, segment.Replace('.', '/'), typeName + ".g.cs");
+                : Path.Combine(fullBasePath, segment.Replace('.', Path.DirectorySeparatorChar), typeName + ".g.cs");
         }
 
         private static void WriteFile(string code, string path)


### PR DESCRIPTION
Trying to run Mapster.Tool in the docker build process, I came across an error, I believe the error is due to the character that separates the directory hierarchy, the error can be seen in issue #368 