### PR TITLE
Fixes #385 Private Sets

### DIFF
--- a/src/Mapster.Tests/WhenMappingToConstructorAndPrivateSetters.cs
+++ b/src/Mapster.Tests/WhenMappingToConstructorAndPrivateSetters.cs
@@ -1,0 +1,71 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Shouldly;
+
+namespace Mapster.Tests
+{
+    [TestClass]
+    public class WhenMappingToConstructorAndPrivateSetters
+    {
+        [TestInitialize]
+        public void Setup()
+        {
+            TypeAdapterConfig.GlobalSettings.Clear();
+        }
+
+        [TestMethod]
+        public void MapToConstructor_Auto()
+        {
+            TypeAdapterConfig<Poco, Dto>.NewConfig()
+                .MapToConstructor(true);
+
+            var poco = new Poco { Id = "A", Name = "Test", Prop = "Prop" };
+            var dto = poco.Adapt<Dto>();
+
+            dto.Id.ShouldBe(poco.Id + "Suffix");
+            dto.Name.ShouldBe(poco.Name + "Suffix");
+            dto.Age.ShouldBe(-1);
+            dto.Prop.ShouldBe(poco.Prop);
+            dto.OtherProp.ShouldBeNull();
+        }
+
+        [TestMethod]
+        public void MapToConstructor_Auto_ReusingSourceProperty()
+        {
+            TypeAdapterConfig<Poco, Dto>.NewConfig()
+                .MapToConstructor(true)
+                .Map((d)=> d.OtherProp, (s) => s.Id);
+
+            var poco = new Poco { Id = "A", Name = "Test", Prop = "Prop" };
+            var dto = poco.Adapt<Dto>();
+
+            dto.Id.ShouldBe(poco.Id + "Suffix");
+            dto.Name.ShouldBe(poco.Name + "Suffix");
+            dto.Age.ShouldBe(-1);
+            dto.Prop.ShouldBe(poco.Prop);
+            dto.OtherProp.ShouldBe(poco.Id);
+        }
+
+        public class Poco
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+            public string Prop { get; set; }
+        }
+
+        public class Dto
+        {
+            public string Id { get; private set; }
+            public string Name { get; private set; }
+            public int Age { get; private set; }
+            public string Prop { get; private set; }
+            public string OtherProp { get; private set; }
+
+            public Dto(string id, string name, int age = -1)
+            {
+                this.Id = id + "Suffix";
+                this.Name = name + "Suffix";
+                this.Age = age;
+            }
+        }
+    }
+}

--- a/src/Mapster/Adapters/ClassAdapter.cs
+++ b/src/Mapster/Adapters/ClassAdapter.cs
@@ -176,7 +176,7 @@ namespace Mapster.Adapters
             var exp = CreateInstantiationExpression(source, arg);
             var memberInit = exp as MemberInitExpression;
             var newInstance = memberInit?.NewExpression ?? (NewExpression)exp;
-
+            var contructorMembers = newInstance.Arguments.OfType<MemberExpression>().Select(me => me.Member).ToArray();
             var classModel = GetSetterModel(arg);
             var classConverter = CreateClassConverter(source, classModel, arg);
             var members = classConverter.Members;
@@ -188,6 +188,11 @@ namespace Mapster.Adapters
             {
                 if (member.UseDestinationValue)
                     return null;
+
+                if (!arg.Settings.Resolvers.Any(r => r.DestinationMemberName == member.DestinationMember.Name) 
+                    && member.Getter is MemberExpression memberExp && contructorMembers.Contains(memberExp.Member))
+                    continue;
+
                 if (member.DestinationMember.SetterModifier == AccessModifier.None)
                     continue;
 


### PR DESCRIPTION
Ensures that if a source property was used in constructor that it will only be reapplied with an explicit resolver.