### PR TITLE
The culture problem has been fixed

### DIFF
--- a/src/Mapster.Core/Utils/NameHelper.cs
+++ b/src/Mapster.Core/Utils/NameHelper.cs
@@ -7,10 +7,10 @@ namespace Mapster.Utils
     {
         internal static string Identity(string s) => s;
         internal static string PascalCase(string s) => string.Concat(BreakWords(s).Select(ProperCase));
-        internal static string CamelCase(string s) => string.Concat(BreakWords(s).Select((w, i) => i == 0 ? w.ToLower() : ProperCase(w)));
-        internal static string LowerCase(string s) => s.ToLower();
+        internal static string CamelCase(string s) => string.Concat(BreakWords(s).Select((w, i) => i == 0 ? w.ToLowerInvariant() : ProperCase(w)));
+        internal static string LowerCase(string s) => s.ToLowerInvariant();
 
-        private static string ProperCase(string s) => s.Length == 0 ? s : (char.ToUpper(s[0]) + s.Substring(1).ToLower());
+        private static string ProperCase(string s) => s.Length == 0 ? s : (char.ToUpperInvariant(s[0]) + s.Substring(1).ToLowerInvariant());
 
         enum WordType
         {


### PR DESCRIPTION
During the mapping phase, I encountered a problem caused by the local culture. The `ToLower` and `ToUpper` methods needed to be changed to `ToLowerInvariant` and `ToUpperInvariant`. I fixed this and the unit tests also ran without issue.