### PR TITLE
Add .net 7.0 TFM to all projects (except benchmark)

### DIFF
--- a/src/ExpressionDebugger.Console/ExpressionDebugger.Console.csproj
+++ b/src/ExpressionDebugger.Console/ExpressionDebugger.Console.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
 	<UseNETCoreGenerator>true</UseNETCoreGenerator>
   </PropertyGroup>
 

--- a/src/ExpressionDebugger.Tests/ExpressionDebugger.Tests.csproj
+++ b/src/ExpressionDebugger.Tests/ExpressionDebugger.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/ExpressionDebugger/ExpressionDebugger.csproj
+++ b/src/ExpressionDebugger/ExpressionDebugger.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Authors>Chaowlert Chaisrichalermpol</Authors>
     <Description>Step into debugging from linq expressions</Description>

--- a/src/ExpressionTranslator/ExpressionTranslator.csproj
+++ b/src/ExpressionTranslator/ExpressionTranslator.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Authors>Chaowlert Chaisrichalermpol</Authors>
     <Description>Translate from linq expressions to C# code</Description>

--- a/src/Mapster.Async.Tests/Mapster.Async.Tests.csproj
+++ b/src/Mapster.Async.Tests/Mapster.Async.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Mapster.Async/Mapster.Async.csproj
+++ b/src/Mapster.Async/Mapster.Async.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
     <Description>Async supports for Mapster</Description>
     <IsPackable>true</IsPackable>
     <PackageTags>Mapster;Async</PackageTags>

--- a/src/Mapster.Core/Mapster.Core.csproj
+++ b/src/Mapster.Core/Mapster.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Lightweight library for Mapster and Mapster CodeGen</Description>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
     <AssemblyName>Mapster.Core</AssemblyName>
     <PackageTags>mapster</PackageTags>
     <Version>1.2.1-pre02</Version>

--- a/src/Mapster.DependencyInjection.Tests/Mapster.DependencyInjection.Tests.csproj
+++ b/src/Mapster.DependencyInjection.Tests/Mapster.DependencyInjection.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Mapster.DependencyInjection/Mapster.DependencyInjection.csproj
+++ b/src/Mapster.DependencyInjection/Mapster.DependencyInjection.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
     <Description>Dependency Injection supports for Mapster</Description>
     <IsPackable>true</IsPackable>
     <PackageTags>Mapster;DependencyInjection</PackageTags>

--- a/src/Mapster.EF6/Mapster.EF6.csproj
+++ b/src/Mapster.EF6/Mapster.EF6.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
     <Description>EF6 plugin for Mapster</Description>
     <IsPackable>true</IsPackable>
 	<PackageTags>Mapster;EF6</PackageTags>

--- a/src/Mapster.EFCore.Tests/Mapster.EFCore.Tests.csproj
+++ b/src/Mapster.EFCore.Tests/Mapster.EFCore.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Mapster.EFCore/Mapster.EFCore.csproj
+++ b/src/Mapster.EFCore/Mapster.EFCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
     <Description>EFCore plugin for Mapster</Description>
 	<IsPackable>true</IsPackable>
     <PackageTags>Mapster;EFCore</PackageTags>

--- a/src/Mapster.Immutable.Tests/Mapster.Immutable.Tests.csproj
+++ b/src/Mapster.Immutable.Tests/Mapster.Immutable.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Mapster.Immutable/Mapster.Immutable.csproj
+++ b/src/Mapster.Immutable/Mapster.Immutable.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
     <Description>Immutable collection supports for Mapster</Description>
     <IsPackable>true</IsPackable>
     <PackageTags>Mapster;Immutable</PackageTags>

--- a/src/Mapster.JsonNet.Tests/Mapster.JsonNet.Tests.csproj
+++ b/src/Mapster.JsonNet.Tests/Mapster.JsonNet.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Mapster.JsonNet/Mapster.JsonNet.csproj
+++ b/src/Mapster.JsonNet/Mapster.JsonNet.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
     <Description>Json.net conversion supports for Mapster</Description>
     <IsPackable>true</IsPackable>
     <PackageTags>Mapster;Json.net</PackageTags>

--- a/src/Mapster.SourceGenerator/Mapster.SourceGenerator.csproj
+++ b/src/Mapster.SourceGenerator/Mapster.SourceGenerator.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFrameworks>net7.0;net6.0</TargetFrameworks>
 		<Description>Source generator to generate mapping using Mapster</Description>
 		<PackageTags>source-generator;mapster</PackageTags>
 		<SignAssembly>true</SignAssembly>

--- a/src/Mapster.Tests/Mapster.Tests.csproj
+++ b/src/Mapster.Tests/Mapster.Tests.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <AssemblyName>Mapster.Tests</AssemblyName>
         <AssemblyOriginatorKeyFile>Mapster.Tests.snk</AssemblyOriginatorKeyFile>

--- a/src/Mapster.Tool/Mapster.Tool.csproj
+++ b/src/Mapster.Tool/Mapster.Tool.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-mapster</ToolCommandName>

--- a/src/Mapster/Mapster.csproj
+++ b/src/Mapster/Mapster.csproj
@@ -4,7 +4,7 @@
     <Description>A fast, fun and stimulating object to object mapper.  Kind of like AutoMapper, just simpler and way, way faster.</Description>
     <Copyright>Copyright (c) 2016 Chaowlert Chaisrichalermpol, Eric Swann</Copyright>
     <Authors>chaowlert;eric_swann</Authors>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
     <AssemblyName>Mapster</AssemblyName>
     <Description>A fast, fun and stimulating object to object mapper. Kind of like AutoMapper, just simpler and way, way faster.</Description>
     <PackageId>Mapster</PackageId>

--- a/src/Sample.AspNetCore/Sample.AspNetCore.csproj
+++ b/src/Sample.AspNetCore/Sample.AspNetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Sample.AspNetCore/Startup.cs
+++ b/src/Sample.AspNetCore/Startup.cs
@@ -1,6 +1,8 @@
 using System.Linq.Expressions;
 using ExpressionDebugger;
+#if NET6_0
 using Hellang.Middleware.ProblemDetails;
+#endif
 using Mapster;
 using Sample.AspNetCore.Controllers;
 using Sample.AspNetCore.Models;
@@ -69,7 +71,9 @@ namespace Sample.AspNetCore
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
+            #if NET6_0
             app.UseProblemDetails();
+            #endif
             app.UseRouting();
             app.UseAuthorization();
             app.UseMvc();

--- a/src/Sample.CodeGen/Sample.CodeGen.csproj
+++ b/src/Sample.CodeGen/Sample.CodeGen.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/src/Sample.CodeGen/Startup.cs
+++ b/src/Sample.CodeGen/Startup.cs
@@ -1,4 +1,6 @@
+#if NET6_0
 using Hellang.Middleware.ProblemDetails;
+#endif
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.OData;
@@ -27,6 +29,7 @@ namespace Sample.CodeGen
                 .AddNewtonsoftJson();
             services.AddDbContext<SchoolContext>(options => 
                 options.UseSqlServer(Configuration.GetConnectionString("DefaultConnection")));
+            
             services.AddProblemDetails();
             services.Scan(selector => selector.FromCallingAssembly()
                 .AddClasses().AsMatchingInterface().WithSingletonLifetime());
@@ -35,7 +38,9 @@ namespace Sample.CodeGen
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
+            #if NET6_0
             app.UseProblemDetails();
+            #endif
             app.UseRouting();
             app.UseAuthorization();
             app.UseMvc();

--- a/src/TemplateTest/TemplateTest.csproj
+++ b/src/TemplateTest/TemplateTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
Do so whilst maintaining the .net 6 TFM using multitargeting thus allowing project to be used by .net6 and .net 7 users and making tests run in both .net 6 and .net 7.

This fixes https://github.com/MapsterMapper/Mapster/issues/475.

It is similar to the PR here https://github.com/MapsterMapper/Mapster/pull/489 which only targets .net 7.

Also fix AddProblemDetails in sample project to use third party extension in .net 6 and built in service in .net 7 (doing this avoids naming collision because the third party library in use and the built in feature in .net 7 both use services.AddProblemDetails() ).

https://andrewlock.net/handling-web-api-exceptions-with-problemdetails-middleware/