### PR TITLE
Add extension method for adding IMapper to service collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,22 @@ You create the object, Mapster maps to the object.
 sourceObject.Adapt(destObject);
 ```
 
+#### You can get IMapper instance via dependency injection so you do not have to change code when migrating to mapster from automapper
+Add Mapster to service collection
+```csharp
+services.AddMapster();
+```
+And use it with DI
+```csharp
+public class Test
+{
+    public Test(IMapper mapper)
+    {
+        var sourceObject = mapper.Adapt<Destination>();
+    }
+}
+```
+
 #### Queryable Extensions
 Mapster also provides extensions to map queryables.
 

--- a/src/Mapster.DependencyInjection/Mapster.DependencyInjection.csproj
+++ b/src/Mapster.DependencyInjection/Mapster.DependencyInjection.csproj
@@ -7,10 +7,11 @@
     <PackageTags>Mapster;DependencyInjection</PackageTags>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>Mapster.DependencyInjection.snk</AssemblyOriginatorKeyFile>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
     <PackageReference Include="System.ComponentModel" Version="4.3.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
     <None Include="icon.png" Pack="true" PackagePath="\" />

--- a/src/Mapster.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Mapster.DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,0 +1,13 @@
+﻿using MapsterMapper;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Mapster
+{
+    public static class ServiceCollectionExtensions
+    {
+        public static void AddMapster(this IServiceCollection serviceCollection)
+        {
+            serviceCollection.AddTransient<IMapper, Mapper>();
+        }
+    }
+}


### PR DESCRIPTION
I think this method is crucial when a developer is trying to migrate from AutoMapper to Mapster
I created a test method for this feature that ran successfully and placed it in the dependency injection tests