### PR TITLE
Add options to Mapster.Tool to generate files with #nullable directives

### DIFF
--- a/src/ExpressionTranslator/ExpressionTranslator.cs
+++ b/src/ExpressionTranslator/ExpressionTranslator.cs
@@ -1896,7 +1896,7 @@ namespace ExpressionDebugger
                     }
 
                     // NOTE: type alias cannot solve all name conflicted case, user should use PrintFullTypeName
-                    // keep logic here for compatability
+                    // keep logic here for compatibility
                     if (_typeNames != null)
                     {
                         var names = _typeNames

--- a/src/Mapster.Tool/ExtensionOptions.cs
+++ b/src/Mapster.Tool/ExtensionOptions.cs
@@ -25,6 +25,9 @@ namespace Mapster.Tool
         [Option('s', "skipExisting", Required = false, HelpText = "Set true to skip generating already existing files")]
         public bool SkipExistingFiles { get; set; }
 
+        [Option("nullableDirective", Required = false, HelpText = "Set true to add \"#nullable enable\" to the top of generated extension files")]
+        public bool GenerateNullableDirective { get; set; }
+
         [Usage(ApplicationAlias = "dotnet mapster extension")]
         public static IEnumerable<Example> Examples =>
             new List<Example>

--- a/src/Mapster.Tool/ExtensionOptions.cs
+++ b/src/Mapster.Tool/ExtensionOptions.cs
@@ -25,7 +25,7 @@ namespace Mapster.Tool
         [Option('s', "skipExisting", Required = false, HelpText = "Set true to skip generating already existing files")]
         public bool SkipExistingFiles { get; set; }
 
-        [Option("nullableDirective", Required = false, HelpText = "Set true to add \"#nullable enable\" to the top of generated extension files")]
+        [Option('N', "nullableDirective", Required = false, HelpText = "Set true to add \"#nullable enable\" to the top of generated extension files")]
         public bool GenerateNullableDirective { get; set; }
 
         [Usage(ApplicationAlias = "dotnet mapster extension")]

--- a/src/Mapster.Tool/MapperOptions.cs
+++ b/src/Mapster.Tool/MapperOptions.cs
@@ -25,6 +25,9 @@ namespace Mapster.Tool
         [Option('s', "skipExisting", Required = false, HelpText = "Set true to skip generating already existing files")]
         public bool SkipExistingFiles { get; set; }
 
+        [Option("nullableDirective", Required = false, HelpText = "Set true to add \"#nullable enable\" to the top of generated mapper files")]
+        public bool GenerateNullableDirective { get; set; }
+
         [Usage(ApplicationAlias = "dotnet mapster mapper")]
         public static IEnumerable<Example> Examples =>
             new List<Example>

--- a/src/Mapster.Tool/MapperOptions.cs
+++ b/src/Mapster.Tool/MapperOptions.cs
@@ -25,7 +25,7 @@ namespace Mapster.Tool
         [Option('s', "skipExisting", Required = false, HelpText = "Set true to skip generating already existing files")]
         public bool SkipExistingFiles { get; set; }
 
-        [Option("nullableDirective", Required = false, HelpText = "Set true to add \"#nullable enable\" to the top of generated mapper files")]
+        [Option('N', "nullableDirective", Required = false, HelpText = "Set true to add \"#nullable enable\" to the top of generated mapper files")]
         public bool GenerateNullableDirective { get; set; }
 
         [Usage(ApplicationAlias = "dotnet mapster mapper")]

--- a/src/Mapster.Tool/ModelOptions.cs
+++ b/src/Mapster.Tool/ModelOptions.cs
@@ -28,7 +28,7 @@ namespace Mapster.Tool
         [Option('s', "skipExisting", Required = false, HelpText = "Set true to skip generating already existing files")]
         public bool SkipExistingFiles { get; set; }
 
-        [Option("nullableDirective", Required = false, HelpText = "Set true to add \"#nullable enable\" to the top of generated model files")]
+        [Option('N', "nullableDirective", Required = false, HelpText = "Set true to add \"#nullable enable\" to the top of generated model files")]
         public bool GenerateNullableDirective { get; set; }
 
         [Usage(ApplicationAlias = "dotnet mapster model")]

--- a/src/Mapster.Tool/ModelOptions.cs
+++ b/src/Mapster.Tool/ModelOptions.cs
@@ -28,6 +28,9 @@ namespace Mapster.Tool
         [Option('s', "skipExisting", Required = false, HelpText = "Set true to skip generating already existing files")]
         public bool SkipExistingFiles { get; set; }
 
+        [Option("nullableDirective", Required = false, HelpText = "Set true to add \"#nullable enable\" to the top of generated model files")]
+        public bool GenerateNullableDirective { get; set; }
+
         [Usage(ApplicationAlias = "dotnet mapster model")]
         public static IEnumerable<Example> Examples =>
             new List<Example>

--- a/src/Mapster.Tool/Program.cs
+++ b/src/Mapster.Tool/Program.cs
@@ -133,7 +133,9 @@ namespace Mapster.Tool
                     }
                 }
 
-                var code = translator.ToString();
+                var code = opt.GenerateNullableDirective ?
+                    $"#nullable enable{Environment.NewLine}{translator}" :
+                    translator.ToString();
                 WriteFile(code, path);
             }
         }
@@ -266,7 +268,9 @@ namespace Mapster.Tool
                 });
             }
 
-            var code = translator.ToString();
+            var code = opt.GenerateNullableDirective ?
+                $"#nullable enable{Environment.NewLine}{translator}" :
+                translator.ToString();
             WriteFile(code, path);
 
             static Type getPropType(MemberInfo mem)
@@ -481,7 +485,9 @@ namespace Mapster.Tool
                     GenerateExtensionMethods(mapType, config, tuple, translator, type, mapperAttr.IsHelperClass);
                 }
 
-                var code = translator.ToString();
+                var code = opt.GenerateNullableDirective ?
+                    $"#nullable enable{Environment.NewLine}{translator}" :
+                    translator.ToString();
                 WriteFile(code, path);
             }
         }


### PR DESCRIPTION
Fixes https://github.com/MapsterMapper/Mapster/issues/337 for Mapster.Tool

This allows to add "--nullableDirective" to the options already set within a given csproj file to add an `#nullable enable`, in order to suppress CS8669 warnings that are raised specifically due to generated source files having to add this directive even if a project has `Nullable` enabled.