### PR TITLE
Add IMapFrom interface for automatic mapping configuration 

### DIFF
--- a/src/Mapster.Tests/WhenUsingIMapFrom.cs
+++ b/src/Mapster.Tests/WhenUsingIMapFrom.cs
@@ -1,0 +1,69 @@
+using System.Reflection;
+using Mapster.Utils;
+using MapsterMapper;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Shouldly;
+
+namespace Mapster.Tests;
+
+[TestClass]
+public class WhenUsingIMapFrom
+{
+    private readonly Mapper _mapper;
+
+    public WhenUsingIMapFrom()
+    {
+        _mapper = new Mapper();
+        TypeAdapterConfig.GlobalSettings.ScanInheritedTypes(Assembly.GetExecutingAssembly());
+    }
+
+    [TestMethod]
+    public void TestIMapFrom_WhenMethodIsNotImplemented()
+    {
+        var source = new SourceModel(DesireValues.Text);
+        var destination = _mapper.Map<DestinationModel>(source);
+        destination.Type.ShouldBe(DesireValues.Text);
+    }
+
+    [TestMethod]
+    public void TestIMapFrom_WhenMethodImplemented()
+    {
+        var source = new SourceModel(DesireValues.Text);
+        var destination = _mapper.Map<InheritedDestinationModel>(source);
+        destination.Type.ShouldBe(DesireValues.Text);
+        destination.Value.ShouldBe(9);
+    }
+}
+
+internal static class DesireValues
+{
+    internal const string Text = "Test";
+    internal const int Number = 9;
+}
+
+public class SourceModel
+{
+    public SourceModel(string type)
+    {
+        Type = type;
+    }
+
+    public string Type { get; set; }
+}
+
+public class InheritedDestinationModel : IMapFrom<SourceModel>
+{
+    public string Type { get; set; }
+    public int Value { get; set; }
+
+    public void ConfigureMapping(TypeAdapterConfig config)
+    {
+        config.NewConfig<SourceModel, InheritedDestinationModel>()
+            .Map(dest => dest.Value, _ => DesireValues.Number);
+    }
+}
+
+public class DestinationModel : IMapFrom<SourceModel>
+{
+    public string Type { get; set; }
+}

--- a/src/Mapster.Tests/WhenUsingIMapFromWrong.cs
+++ b/src/Mapster.Tests/WhenUsingIMapFromWrong.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Reflection;
+using Mapster.Utils;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Shouldly;
+
+namespace Mapster.Tests;
+
+[TestClass]
+public class WhenUsingIMapFromWrong
+{
+    [TestMethod]
+    public void TestIMapFrom_WhenMethodImplementedWrong_ShouldRaiseException()
+    {
+        Should.Throw<Exception>(() =>
+        {
+            TypeAdapterConfig.GlobalSettings.ScanInheritedTypes(Assembly.GetExecutingAssembly());
+        });
+    }
+}
+
+public class WrongInheritedDestinationModel : IMapFrom<SourceModel>
+{
+    public string Type { get; set; }
+    public int Value { get; set; }
+
+    public void ConfigureMapping()
+    {
+        TypeAdapterConfig.GlobalSettings
+            .NewConfig<SourceModel, InheritedDestinationModel>()
+            .Map(dest => dest.Value, _ => DesireValues.Number);
+    }
+}

--- a/src/Mapster/Interfaces/IMapFrom.cs
+++ b/src/Mapster/Interfaces/IMapFrom.cs
@@ -1,0 +1,9 @@
+namespace Mapster;
+
+public interface IMapFrom<TSource>
+{
+    public void ConfigureMapping(TypeAdapterConfig config)
+    {
+        config.NewConfig(typeof(TSource), GetType());
+    }
+}

--- a/src/Mapster/Utils/InterfaceDynamicMapper.cs
+++ b/src/Mapster/Utils/InterfaceDynamicMapper.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace Mapster.Utils;
+
+public class InterfaceDynamicMapper
+{
+    private readonly TypeAdapterConfig _config;
+    private readonly Assembly _assembly;
+
+    public InterfaceDynamicMapper(TypeAdapterConfig config, Assembly assembly)
+    {
+        _config = config;
+        _assembly = assembly;
+    }
+
+    internal void ApplyMappingFromAssembly()
+    {
+        var types = _assembly.GetTypes()
+            .Where(t =>
+                t.GetInterfaces()
+                    .Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IMapFrom<>)));
+
+        foreach (var type in types)
+        {
+            var instance = Activator.CreateInstance(type);
+            var method = GetMethod(type);
+            method!.Invoke(instance, new object[] { _config });
+        }
+    }
+
+    private static MethodInfo GetMethod(Type type)
+    {
+        const string methodName = "ConfigureMapping";
+        var method = type.GetMethod(methodName);
+        if (method == null) return type.GetInterface("IMapFrom`1")!.GetMethod(methodName)!;
+        var parameters = method.GetParameters();
+        var condition = parameters.Length == 1 && parameters[0].ParameterType == typeof(TypeAdapterConfig);
+        if (!condition)
+        {
+            throw new Exception($"{methodName} is not implemented right or it's ambiguous!");
+        }
+
+        return method;
+    }
+}

--- a/src/Mapster/Utils/TypeAdapterConfigExtensions.cs
+++ b/src/Mapster/Utils/TypeAdapterConfigExtensions.cs
@@ -1,0 +1,12 @@
+using System.Reflection;
+
+namespace Mapster.Utils;
+
+public static class TypeAdapterConfigExtensions
+{
+    public static void ScanInheritedTypes(this TypeAdapterConfig config, Assembly assembly)
+    {
+        InterfaceDynamicMapper dynamicMapper = new(config, assembly);
+        dynamicMapper.ApplyMappingFromAssembly();
+    }
+}


### PR DESCRIPTION
Creating IMapFrom interface
now destination type can inherit from an interface named IMapFrom and they can configure mapping in the same class like this:
```csharp
public class InheritedDestinationModel : IMapFrom<SourceModel>
{
    public string Type { get; set; }
    public int Value { get; set; }

    public void ConfigureMapping(TypeAdapterConfig config)
    {
        config.NewConfig<SourceModel, InheritedDestinationModel>()
            .Map(dest => dest.Value, _ => DesireValues.Number);
    }
}
```

and even if you don't implement the method it will automatically create a new config for desire types
ex:
```csharp
public class DestinationModel : IMapFrom<SourceModel>
{
    public string Type { get; set; }
}
```
I've added a new extension method to TypeAdapterConfig named ScanInheritedTypes like this:
```csharp
TypeAdapterConfig.GlobalSettings.ScanInheritedTypes(Assembly.GetExecutingAssembly());
```

I've created tests for all situations and tests are passed
as soon as this pull request merged I will update wiki page