### PR TITLE
Fix Issues #536 -> Set properties with reflection if destination has init only properties.

### DIFF
--- a/src/Mapster.Tool.Tests/.config/dotnet-tools.json
+++ b/src/Mapster.Tool.Tests/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "mapster.tool": {
+      "version": "8.3.0",
+      "commands": [
+        "dotnet-mapster"
+      ]
+    }
+  }
+}

--- a/src/Mapster.Tool.Tests/Mappers/IUserMapper.cs
+++ b/src/Mapster.Tool.Tests/Mappers/IUserMapper.cs
@@ -1,0 +1,11 @@
+using System.Linq.Expressions;
+
+namespace Mapster.Tool.Tests.Mappers;
+
+[Mapper]
+public interface IUserMapper
+{
+    Expression<Func<_User, _UserDto>> UserProjection { get; }
+    _UserDto MapTo(_User user);
+    _UserDto MapTo(_User user, _UserDto userDto);
+}

--- a/src/Mapster.Tool.Tests/Mappers/UserMapper.cs
+++ b/src/Mapster.Tool.Tests/Mappers/UserMapper.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Linq.Expressions;
+using Mapster.Tool.Tests;
+using Mapster.Tool.Tests.Mappers;
+
+namespace Mapster.Tool.Tests.Mappers
+{
+    public partial class UserMapper : IUserMapper
+    {
+        public Expression<Func<_User, _UserDto>> UserProjection => p1 => new _UserDto()
+        {
+            Id = p1.Id,
+            Name = p1.Name
+        };
+        public _UserDto MapTo(_User p2)
+        {
+            return p2 == null ? null : new _UserDto()
+            {
+                Id = p2.Id,
+                Name = p2.Name
+            };
+        }
+        public _UserDto MapTo(_User p3, _UserDto p4)
+        {
+            if (p3 == null)
+            {
+                return null;
+            }
+            _UserDto result = p4 ?? new _UserDto();
+            
+            typeof(_UserDto).GetProperty("Id").SetValue(result, (object)p3.Id);
+            typeof(_UserDto).GetProperty("Name").SetValue(result, p3.Name);
+            return result;
+            
+        }
+    }
+}

--- a/src/Mapster.Tool.Tests/Mapster.Tool.Tests.csproj
+++ b/src/Mapster.Tool.Tests/Mapster.Tool.Tests.csproj
@@ -1,0 +1,52 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="FluentAssertions" Version="6.9.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+        <PackageReference Include="Scrutor" Version="4.2.1" />
+        <PackageReference Include="xunit" Version="2.4.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="3.1.2">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+    <ItemGroup>
+        <Generated Include="**\*.g.cs" />
+        <Generated Remove="obj\**" />
+    </ItemGroup>
+    <Target Name="CleanGenerated">
+        <Delete Files="@(Generated)" />
+    </Target>
+    <Target Name="Mapster">
+        <Exec WorkingDirectory="$(ProjectDir)" Command="dotnet build" />
+        <Exec WorkingDirectory="$(ProjectDir)" Command="dotnet tool restore" />
+        <Exec WorkingDirectory="$(ProjectDir)" Command="dotnet mapster model -a $(TargetDir)$(ProjectName).dll -n Sample.CodeGen.Models -o Models -r" />
+        <Exec WorkingDirectory="$(ProjectDir)" Command="dotnet mapster extension -a $(TargetDir)$(ProjectName).dll -n Sample.CodeGen.Models -o Models" />
+        <Exec WorkingDirectory="$(ProjectDir)" Command="dotnet mapster mapper -a $(TargetDir)$(ProjectName).dll -n Sample.CodeGen.Mappers -o Mappers" />
+    </Target>
+    <ItemGroup>
+      <Compile Remove="obj\**" />
+    </ItemGroup>
+    <ItemGroup>
+      <EmbeddedResource Remove="obj\**" />
+    </ItemGroup>
+    <ItemGroup>
+      <None Remove="obj\**" />
+    </ItemGroup>
+    <ItemGroup>
+      <ProjectReference Include="..\Mapster.Tool\Mapster.Tool.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/Mapster.Tool.Tests/TestBase.cs
+++ b/src/Mapster.Tool.Tests/TestBase.cs
@@ -1,0 +1,38 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Mapster.Tool.Tests;
+
+public class TestBase
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+
+    public TestBase()
+    {
+        var services = ConfigureServiceCollection();
+        using var scope = services.BuildServiceProvider().CreateScope();
+        _scopeFactory = scope.ServiceProvider.GetRequiredService<IServiceScopeFactory>();
+    }
+
+    private ServiceCollection ConfigureServiceCollection()
+    {
+        ServiceCollection services = new();
+        services.Scan(selector => selector
+            .FromCallingAssembly()
+            .AddClasses()
+            .AsMatchingInterface()
+            .WithSingletonLifetime());
+        return services;
+    }
+
+    protected TInterface GetMappingInterface<TInterface>()
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var service = scope.ServiceProvider.GetService(typeof(TInterface));
+        if (service == null)
+        {
+            throw new Exception($"Service of type {typeof(TInterface).Name} not found!");
+        }
+
+        return (TInterface)service;
+    }
+}

--- a/src/Mapster.Tool.Tests/Usings.cs
+++ b/src/Mapster.Tool.Tests/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/src/Mapster.Tool.Tests/WhenMappingWithExistingObjectAndInitProperties.cs
+++ b/src/Mapster.Tool.Tests/WhenMappingWithExistingObjectAndInitProperties.cs
@@ -1,0 +1,46 @@
+using System.Reflection;
+using FluentAssertions;
+using Mapster.Tool.Tests.Mappers;
+
+namespace Mapster.Tool.Tests;
+
+/// <summary>
+/// Tests for https://github.com/MapsterMapper/Mapster/issues/536
+/// </summary>
+public class WhenMappingWithExistingObjectAndInitProperties : TestBase
+{
+    [Fact]
+    public void Map()
+    {
+        TypeAdapterConfig.GlobalSettings
+            .Scan(Assembly.GetExecutingAssembly());
+        
+        var userMapper = GetMappingInterface<IUserMapper>();
+        var user = new _User { Name = "Aref", Id = 1 };
+        var dto = new _UserDto();
+        userMapper.MapTo(user, dto);
+        dto.Name.Should().Be("Aref");
+    }
+}
+
+public class UserMappingRegister : IRegister
+{
+    public void Register(TypeAdapterConfig config)
+    {
+        config.NewConfig<_User, _UserDto>()
+            .MapToConstructor(true)
+            .ConstructUsing(s => new _UserDto());
+    }
+}
+
+public class _User
+{
+    public int Id { get; init; }
+    public string Name { get; init; }
+}
+
+public class _UserDto
+{
+    public int Id { get; init; }
+    public string Name { get; init; }
+}

--- a/src/Mapster.Tool.Tests/WhenMappingWithExistingObjectAndInitProperties.cs
+++ b/src/Mapster.Tool.Tests/WhenMappingWithExistingObjectAndInitProperties.cs
@@ -10,16 +10,17 @@ namespace Mapster.Tool.Tests;
 public class WhenMappingWithExistingObjectAndInitProperties : TestBase
 {
     [Fact]
-    public void Map()
+    public void MapWithReflection()
     {
         TypeAdapterConfig.GlobalSettings
             .Scan(Assembly.GetExecutingAssembly());
         
         var userMapper = GetMappingInterface<IUserMapper>();
-        var user = new _User { Name = "Aref", Id = 1 };
+        var expected = "Aref";
+        var user = new _User { Name = expected, Id = 1 };
         var dto = new _UserDto();
         userMapper.MapTo(user, dto);
-        dto.Name.Should().Be("Aref");
+        dto.Name.Should().Be(expected);
     }
 }
 

--- a/src/Mapster.sln
+++ b/src/Mapster.sln
@@ -61,6 +61,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExpressionTranslator", "Exp
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TemplateTest", "TemplateTest\TemplateTest.csproj", "{ED390145-FA22-46BA-86A6-9FA6AC869BA4}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mapster.Tool.Tests", "Mapster.Tool.Tests\Mapster.Tool.Tests.csproj", "{E64E9CEB-8FB2-4012-BBA8-4C2B99FD54C1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -155,6 +157,10 @@ Global
 		{ED390145-FA22-46BA-86A6-9FA6AC869BA4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{ED390145-FA22-46BA-86A6-9FA6AC869BA4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{ED390145-FA22-46BA-86A6-9FA6AC869BA4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E64E9CEB-8FB2-4012-BBA8-4C2B99FD54C1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E64E9CEB-8FB2-4012-BBA8-4C2B99FD54C1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E64E9CEB-8FB2-4012-BBA8-4C2B99FD54C1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E64E9CEB-8FB2-4012-BBA8-4C2B99FD54C1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -175,6 +181,7 @@ Global
 		{D5DF0FB7-44A5-4326-9EC4-5B8F7FCCE00F} = {D33E5A90-ABCA-4B2D-8758-2873CC5AB847}
 		{3CB56440-5449-4DE5-A8D3-549C87C1B36A} = {EF7E343F-592E-4EAC-A0A4-92EB4B95CB89}
 		{ED390145-FA22-46BA-86A6-9FA6AC869BA4} = {D33E5A90-ABCA-4B2D-8758-2873CC5AB847}
+		{E64E9CEB-8FB2-4012-BBA8-4C2B99FD54C1} = {D33E5A90-ABCA-4B2D-8758-2873CC5AB847}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {83B87DBA-277C-49F1-B597-E3B78C2C8275}

--- a/src/Mapster/Adapters/ClassAdapter.cs
+++ b/src/Mapster/Adapters/ClassAdapter.cs
@@ -236,14 +236,6 @@ namespace Mapster.Adapters
                 {
                     value = member.Getter.NotNullReturn(value);
                 }
-
-                var destinationPropertyInfo = (PropertyInfo)member.DestinationMember.Info!;
-                if (destinationPropertyInfo.IsInitOnly())
-                {
-                    //Todo build expression here instead of binding value
-                    // arg.DestinationType.GetProperty(destinationPropertyInfo.Name).SetValue();
-                }
-                
                 var bind = Expression.Bind((MemberInfo)member.DestinationMember.Info!, value);
                 lines.Add(bind);
             }

--- a/src/Mapster/Adapters/ClassAdapter.cs
+++ b/src/Mapster/Adapters/ClassAdapter.cs
@@ -209,6 +209,14 @@ namespace Mapster.Adapters
                 {
                     value = member.Getter.NotNullReturn(value);
                 }
+
+                var destinationPropertyInfo = (PropertyInfo)member.DestinationMember.Info!;
+                if (destinationPropertyInfo.IsInitOnly())
+                {
+                    //Todo build expression here instead of binding value
+                    // arg.DestinationType.GetProperty(destinationPropertyInfo.Name).SetValue();
+                }
+                
                 var bind = Expression.Bind((MemberInfo)member.DestinationMember.Info!, value);
                 lines.Add(bind);
             }

--- a/src/Mapster/TypeAdapterSetter.cs
+++ b/src/Mapster/TypeAdapterSetter.cs
@@ -16,25 +16,21 @@ namespace Mapster
 
         public readonly TypeAdapterSettings Settings;
         public readonly TypeAdapterConfig Config;
-
         public TypeAdapterSetter(TypeAdapterSettings settings, TypeAdapterConfig config)
         {
             this.Settings = settings;
             this.Config = config;
         }
     }
-
     public static class TypeAdapterSetterExtensions
     {
         internal static void CheckCompiled<TSetter>(this TSetter setter) where TSetter : TypeAdapterSetter
         {
             if (setter.Settings.Compiled)
-                throw new InvalidOperationException(
-                    "TypeAdapter.Adapt was already called, please clone or create new TypeAdapterConfig.");
+                throw new InvalidOperationException("TypeAdapter.Adapt was already called, please clone or create new TypeAdapterConfig.");
         }
 
-        public static TSetter AddDestinationTransform<TSetter, TDestinationMember>(this TSetter setter,
-            Expression<Func<TDestinationMember, TDestinationMember>> transform) where TSetter : TypeAdapterSetter
+        public static TSetter AddDestinationTransform<TSetter, TDestinationMember>(this TSetter setter, Expression<Func<TDestinationMember, TDestinationMember>> transform) where TSetter : TypeAdapterSetter
         {
             setter.CheckCompiled();
 
@@ -46,8 +42,7 @@ namespace Mapster
             return setter;
         }
 
-        public static TSetter AddDestinationTransform<TSetter>(this TSetter setter, DestinationTransform transform)
-            where TSetter : TypeAdapterSetter
+        public static TSetter AddDestinationTransform<TSetter>(this TSetter setter, DestinationTransform transform) where TSetter : TypeAdapterSetter
         {
             setter.CheckCompiled();
 
@@ -55,8 +50,7 @@ namespace Mapster
             return setter;
         }
 
-        public static TSetter Ignore<TSetter>(this TSetter setter, params string[] names)
-            where TSetter : TypeAdapterSetter
+        public static TSetter Ignore<TSetter>(this TSetter setter, params string[] names) where TSetter : TypeAdapterSetter
         {
             setter.CheckCompiled();
 
@@ -64,40 +58,32 @@ namespace Mapster
             {
                 setter.Settings.Ignore[name] = new IgnoreDictionary.IgnoreItem();
             }
-
             return setter;
         }
 
-        public static TSetter IgnoreAttribute<TSetter>(this TSetter setter, params Type[] types)
-            where TSetter : TypeAdapterSetter
+        public static TSetter IgnoreAttribute<TSetter>(this TSetter setter, params Type[] types) where TSetter : TypeAdapterSetter
         {
             setter.CheckCompiled();
 
             foreach (var type in types)
             {
-                setter.Settings.ShouldMapMember.Add(
-                    (member, _) => member.HasCustomAttribute(type) ? (bool?)false : null);
+                setter.Settings.ShouldMapMember.Add((member, _) => member.HasCustomAttribute(type) ? (bool?)false : null);
             }
-
             return setter;
         }
 
-        public static TSetter IncludeAttribute<TSetter>(this TSetter setter, params Type[] types)
-            where TSetter : TypeAdapterSetter
+        public static TSetter IncludeAttribute<TSetter>(this TSetter setter, params Type[] types) where TSetter : TypeAdapterSetter
         {
             setter.CheckCompiled();
 
             foreach (var type in types)
             {
-                setter.Settings.ShouldMapMember.Add((member, _) =>
-                    member.HasCustomAttribute(type) ? (bool?)true : null);
+                setter.Settings.ShouldMapMember.Add((member, _) => member.HasCustomAttribute(type) ? (bool?)true : null);
             }
-
             return setter;
         }
 
-        public static TSetter IgnoreMember<TSetter>(this TSetter setter, Func<IMemberModel, MemberSide, bool> predicate)
-            where TSetter : TypeAdapterSetter
+        public static TSetter IgnoreMember<TSetter>(this TSetter setter, Func<IMemberModel, MemberSide, bool> predicate) where TSetter : TypeAdapterSetter
         {
             setter.CheckCompiled();
 
@@ -105,8 +91,7 @@ namespace Mapster
             return setter;
         }
 
-        public static TSetter IncludeMember<TSetter>(this TSetter setter,
-            Func<IMemberModel, MemberSide, bool> predicate) where TSetter : TypeAdapterSetter
+        public static TSetter IncludeMember<TSetter>(this TSetter setter, Func<IMemberModel, MemberSide, bool> predicate) where TSetter : TypeAdapterSetter
         {
             setter.CheckCompiled();
 
@@ -114,8 +99,7 @@ namespace Mapster
             return setter;
         }
 
-        public static TSetter ShallowCopyForSameType<TSetter>(this TSetter setter, bool value)
-            where TSetter : TypeAdapterSetter
+        public static TSetter ShallowCopyForSameType<TSetter>(this TSetter setter, bool value) where TSetter : TypeAdapterSetter
         {
             setter.CheckCompiled();
 
@@ -123,8 +107,7 @@ namespace Mapster
             return setter;
         }
 
-        public static TSetter EnumMappingStrategy<TSetter>(this TSetter setter, EnumMappingStrategy strategy)
-            where TSetter : TypeAdapterSetter
+        public static TSetter EnumMappingStrategy<TSetter>(this TSetter setter, EnumMappingStrategy strategy) where TSetter : TypeAdapterSetter
         {
             setter.CheckCompiled();
 
@@ -132,8 +115,7 @@ namespace Mapster
             return setter;
         }
 
-        public static TSetter IgnoreNullValues<TSetter>(this TSetter setter, bool value)
-            where TSetter : TypeAdapterSetter
+        public static TSetter IgnoreNullValues<TSetter>(this TSetter setter, bool value) where TSetter : TypeAdapterSetter
         {
             setter.CheckCompiled();
 
@@ -141,8 +123,7 @@ namespace Mapster
             return setter;
         }
 
-        public static TSetter PreserveReference<TSetter>(this TSetter setter, bool value)
-            where TSetter : TypeAdapterSetter
+        public static TSetter PreserveReference<TSetter>(this TSetter setter, bool value) where TSetter : TypeAdapterSetter
         {
             setter.CheckCompiled();
 
@@ -150,8 +131,7 @@ namespace Mapster
             return setter;
         }
 
-        public static TSetter NameMatchingStrategy<TSetter>(this TSetter setter, NameMatchingStrategy value)
-            where TSetter : TypeAdapterSetter
+        public static TSetter NameMatchingStrategy<TSetter>(this TSetter setter, NameMatchingStrategy value) where TSetter : TypeAdapterSetter
         {
             setter.CheckCompiled();
 
@@ -194,8 +174,7 @@ namespace Mapster
         }
 
         public static TSetter Map<TSetter>(
-            this TSetter setter, string destinationMemberName, string sourceMemberName)
-            where TSetter : TypeAdapterSetter
+            this TSetter setter, string destinationMemberName, string sourceMemberName) where TSetter : TypeAdapterSetter
         {
             setter.CheckCompiled();
 
@@ -209,8 +188,7 @@ namespace Mapster
             return setter;
         }
 
-        public static TSetter EnableNonPublicMembers<TSetter>(this TSetter setter, bool value)
-            where TSetter : TypeAdapterSetter
+        public static TSetter EnableNonPublicMembers<TSetter>(this TSetter setter, bool value) where TSetter : TypeAdapterSetter
         {
             setter.CheckCompiled();
 
@@ -218,8 +196,7 @@ namespace Mapster
             return setter;
         }
 
-        public static TSetter IgnoreNonMapped<TSetter>(this TSetter setter, bool value)
-            where TSetter : TypeAdapterSetter
+        public static TSetter IgnoreNonMapped<TSetter>(this TSetter setter, bool value) where TSetter : TypeAdapterSetter
         {
             setter.CheckCompiled();
 
@@ -227,8 +204,7 @@ namespace Mapster
             return setter;
         }
 
-        public static TSetter AvoidInlineMapping<TSetter>(this TSetter setter, bool value)
-            where TSetter : TypeAdapterSetter
+        public static TSetter AvoidInlineMapping<TSetter>(this TSetter setter, bool value) where TSetter : TypeAdapterSetter
         {
             setter.CheckCompiled();
 
@@ -236,8 +212,7 @@ namespace Mapster
             return setter;
         }
 
-        public static TSetter RequireDestinationMemberSource<TSetter>(this TSetter setter, bool value)
-            where TSetter : TypeAdapterSetter
+        public static TSetter RequireDestinationMemberSource<TSetter>(this TSetter setter, bool value) where TSetter : TypeAdapterSetter
         {
             setter.CheckCompiled();
 
@@ -245,8 +220,7 @@ namespace Mapster
             return setter;
         }
 
-        public static TSetter GetMemberName<TSetter>(this TSetter setter, Func<IMemberModel, string?> func)
-            where TSetter : TypeAdapterSetter
+        public static TSetter GetMemberName<TSetter>(this TSetter setter, Func<IMemberModel, string?> func) where TSetter : TypeAdapterSetter
         {
             setter.CheckCompiled();
 
@@ -254,8 +228,7 @@ namespace Mapster
             return setter;
         }
 
-        public static TSetter GetMemberName<TSetter>(this TSetter setter, Func<IMemberModel, MemberSide, string?> func)
-            where TSetter : TypeAdapterSetter
+        public static TSetter GetMemberName<TSetter>(this TSetter setter, Func<IMemberModel, MemberSide, string?> func) where TSetter : TypeAdapterSetter
         {
             setter.CheckCompiled();
 
@@ -263,8 +236,7 @@ namespace Mapster
             return setter;
         }
 
-        public static TSetter MapToConstructor<TSetter>(this TSetter setter, bool value)
-            where TSetter : TypeAdapterSetter
+        public static TSetter MapToConstructor<TSetter>(this TSetter setter, bool value) where TSetter : TypeAdapterSetter
         {
             setter.CheckCompiled();
 
@@ -288,8 +260,7 @@ namespace Mapster
             return setter;
         }
 
-        public static TSetter UseDestinationValue<TSetter>(this TSetter setter, Func<IMemberModel, bool> func)
-            where TSetter : TypeAdapterSetter
+        public static TSetter UseDestinationValue<TSetter>(this TSetter setter, Func<IMemberModel, bool> func) where TSetter : TypeAdapterSetter
         {
             setter.CheckCompiled();
 
@@ -297,8 +268,7 @@ namespace Mapster
             return setter;
         }
 
-        internal static TSetter Include<TSetter>(this TSetter setter, Type sourceType, Type destType)
-            where TSetter : TypeAdapterSetter
+        internal static TSetter Include<TSetter>(this TSetter setter, Type sourceType, Type destType) where TSetter : TypeAdapterSetter
         {
             setter.CheckCompiled();
 
@@ -306,9 +276,7 @@ namespace Mapster
             {
                 Priority = arg =>
                     arg.SourceType == sourceType &&
-                    arg.DestinationType == destType
-                        ? (int?)100
-                        : null,
+                    arg.DestinationType == destType ? (int?)100 : null,
                 Settings = setter.Settings
             });
 
@@ -317,8 +285,7 @@ namespace Mapster
             return setter;
         }
 
-        public static TSetter ApplyAdaptAttribute<TSetter>(this TSetter setter, BaseAdaptAttribute attr)
-            where TSetter : TypeAdapterSetter
+        public static TSetter ApplyAdaptAttribute<TSetter>(this TSetter setter, BaseAdaptAttribute attr) where TSetter : TypeAdapterSetter
         {
             if (attr.IgnoreAttributes != null)
                 setter.IgnoreAttribute(attr.IgnoreAttributes);
@@ -329,7 +296,6 @@ namespace Mapster
                     .Intersect(attr.IgnoreNoAttributes)
                     .Any());
             }
-
             if (attr.IgnoreNamespaces != null)
             {
                 foreach (var ns in attr.IgnoreNamespaces)
@@ -337,7 +303,6 @@ namespace Mapster
                     setter.IgnoreMember((member, _) => member.Type.Namespace?.StartsWith(ns) == true);
                 }
             }
-
             if (attr.MaxDepth > 0)
                 setter.MaxDepth(attr.MaxDepth);
             if (attr.GetBooleanSettingValues(nameof(attr.IgnoreNullValues)) != null)
@@ -358,8 +323,7 @@ namespace Mapster
     {
         internal TypeAdapterSetter(TypeAdapterSettings settings, TypeAdapterConfig parentConfig)
             : base(settings, parentConfig)
-        {
-        }
+        { }
 
         public TypeAdapterSetter<TDestination> Ignore(params Expression<Func<TDestination, object>>[] members)
         {
@@ -369,7 +333,6 @@ namespace Mapster
             {
                 Settings.Ignore[member.GetMemberPath()!] = new IgnoreDictionary.IgnoreItem();
             }
-
             return this;
         }
 
@@ -379,7 +342,7 @@ namespace Mapster
         {
             this.CheckCompiled();
 
-            var invoker = Expression.Lambda(source.Body, Expression.Parameter(typeof(object)));
+            var invoker = Expression.Lambda(source.Body, Expression.Parameter(typeof (object)));
             if (member.IsIdentity())
             {
                 Settings.ExtraSources.Add(invoker);
@@ -458,21 +421,20 @@ namespace Mapster
             return this;
         }
 
-        public TypeAdapterSetter<TDestination> MapToConstructor(ConstructorInfo? ctor)
+        public TypeAdapterSetter<TDestination> MapToConstructor(ConstructorInfo ctor)
         {
             this.CheckCompiled();
-            Settings.MapToConstructor = ctor;
-            if (ctor == null)
+
+            if (ctor != null)
             {
-                return this;
+                if (!typeof(TDestination).GetTypeInfo().IsAssignableFrom(ctor.DeclaringType!.GetTypeInfo()))
+                    throw new ArgumentException("Constructor cannot be assigned to type TDestination", nameof(ctor));
+
+                if (ctor.DeclaringType!.GetTypeInfo().IsAbstract)
+                    throw new ArgumentException("Constructor of abstract type cannot be created", nameof(ctor));
             }
 
-            if (!typeof(TDestination).GetTypeInfo().IsAssignableFrom(ctor.DeclaringType!.GetTypeInfo()))
-                throw new ArgumentException("Constructor cannot be assigned to type TDestination", nameof(ctor));
-
-            if (ctor.DeclaringType!.GetTypeInfo().IsAbstract)
-                throw new ArgumentException("Constructor of abstract type cannot be created", nameof(ctor));
-
+            this.Settings.MapToConstructor = ctor;
             return this;
         }
 
@@ -492,7 +454,7 @@ namespace Mapster
         {
             this.CheckCompiled();
 
-            var lambda = Expression.Lambda(action.Body,
+            var lambda = Expression.Lambda(action.Body, 
                 Expression.Parameter(typeof(object), SourceParameterName),
                 action.Parameters[0]);
             Settings.AfterMappingFactories.Add(arg => lambda);
@@ -500,19 +462,16 @@ namespace Mapster
         }
     }
 
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Minor Code Smell",
-        "S4136:Method overloads should be grouped together", Justification = "<Pending>")]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Minor Code Smell", "S4136:Method overloads should be grouped together", Justification = "<Pending>")]
     public class TypeAdapterSetter<TSource, TDestination> : TypeAdapterSetter<TDestination>
     {
         internal TypeAdapterSetter(TypeAdapterSettings settings, TypeAdapterConfig parentConfig)
             : base(settings, parentConfig)
-        {
-        }
+        { }
 
         #region replace for chaining
 
-        public new TypeAdapterSetter<TSource, TDestination> Ignore(
-            params Expression<Func<TDestination, object>>[] members)
+        public new TypeAdapterSetter<TSource, TDestination> Ignore(params Expression<Func<TDestination, object>>[] members)
         {
             return (TypeAdapterSetter<TSource, TDestination>)base.Ignore(members);
         }
@@ -531,8 +490,7 @@ namespace Mapster
             return (TypeAdapterSetter<TSource, TDestination>)base.Map(destinationMember, sourceMemberName);
         }
 
-        public new TypeAdapterSetter<TSource, TDestination> ConstructUsing(
-            Expression<Func<TDestination>> constructUsing)
+        public new TypeAdapterSetter<TSource, TDestination> ConstructUsing(Expression<Func<TDestination>> constructUsing)
         {
             return (TypeAdapterSetter<TSource, TDestination>)base.ConstructUsing(constructUsing);
         }
@@ -549,7 +507,7 @@ namespace Mapster
 
         public new TypeAdapterSetter<TSource, TDestination> MapToConstructor(ConstructorInfo ctor)
         {
-            return (TypeAdapterSetter<TSource, TDestination>)base.MapToConstructor(ctor);
+            return (TypeAdapterSetter<TSource, TDestination>) base.MapToConstructor(ctor);
         }
 
         public new TypeAdapterSetter<TSource, TDestination> BeforeMappingInline(Expression<Action<TDestination>> action)
@@ -559,7 +517,7 @@ namespace Mapster
 
         public new TypeAdapterSetter<TSource, TDestination> AfterMappingInline(Expression<Action<TDestination>> action)
         {
-            return (TypeAdapterSetter<TSource, TDestination>)base.AfterMappingInline(action);
+            return (TypeAdapterSetter<TSource, TDestination>) base.AfterMappingInline(action);
         }
 
         #endregion
@@ -575,7 +533,6 @@ namespace Mapster
                 var name = member.GetMemberPath()!;
                 Settings.Ignore.Merge(name, new IgnoreDictionary.IgnoreItem(condition, false));
             }
-
             return this;
         }
 
@@ -589,7 +546,6 @@ namespace Mapster
             {
                 Settings.Ignore.Merge(member, new IgnoreDictionary.IgnoreItem(condition, false));
             }
-
             return this;
         }
 
@@ -633,8 +589,7 @@ namespace Mapster
             return this;
         }
 
-        public TypeAdapterSetter<TSource, TDestination> ConstructUsing(
-            Expression<Func<TSource, TDestination>> constructUsing)
+        public TypeAdapterSetter<TSource, TDestination> ConstructUsing(Expression<Func<TSource, TDestination>> constructUsing)
         {
             this.CheckCompiled();
 
@@ -643,8 +598,7 @@ namespace Mapster
             return this;
         }
 
-        public TypeAdapterSetter<TSource, TDestination> ConstructUsing(
-            Expression<Func<TSource, TDestination?, TDestination>> constructUsing)
+        public TypeAdapterSetter<TSource, TDestination> ConstructUsing(Expression<Func<TSource, TDestination?, TDestination>> constructUsing)
         {
             this.CheckCompiled();
 
@@ -653,8 +607,7 @@ namespace Mapster
             return this;
         }
 
-        public TypeAdapterSetter<TSource, TDestination> MapWith(
-            Expression<Func<TSource, TDestination>> converterFactory, bool applySettings = false)
+        public TypeAdapterSetter<TSource, TDestination> MapWith(Expression<Func<TSource, TDestination>> converterFactory, bool applySettings = false)
         {
             this.CheckCompiled();
 
@@ -670,16 +623,14 @@ namespace Mapster
                 if (Settings.ConverterToTargetFactory == null)
                 {
                     var dest = Expression.Parameter(typeof(TDestination));
-                    Settings.ConverterToTargetFactory = arg =>
-                        Expression.Lambda(converterFactory.Body, converterFactory.Parameters[0], dest);
+                    Settings.ConverterToTargetFactory = arg => Expression.Lambda(converterFactory.Body, converterFactory.Parameters[0], dest);
                 }
             }
 
             return this;
         }
 
-        public TypeAdapterSetter<TSource, TDestination> MapToTargetWith(
-            Expression<Func<TSource, TDestination, TDestination>> converterFactory, bool applySettings = false)
+        public TypeAdapterSetter<TSource, TDestination> MapToTargetWith(Expression<Func<TSource, TDestination, TDestination>> converterFactory, bool applySettings = false)
         {
             this.CheckCompiled();
 
@@ -690,7 +641,6 @@ namespace Mapster
             }
             else
                 Settings.ConverterToTargetFactory = arg => converterFactory;
-
             return this;
         }
 
@@ -721,8 +671,7 @@ namespace Mapster
         /// <returns>
         /// The current <see cref="TypeAdapterSetter{TSource, TDestination}"/> instance.
         /// </returns>
-        public TypeAdapterSetter<TSource, TDestination> BeforeMapping(
-            Action<TSource, TDestination, TDestination?> action)
+        public TypeAdapterSetter<TSource, TDestination> BeforeMapping(Action<TSource, TDestination, TDestination?> action)
         {
             this.CheckCompiled();
 
@@ -768,8 +717,7 @@ namespace Mapster
         /// <returns>
         /// The current <see cref="TypeAdapterSetter{TSource, TDestination}"/> instance.
         /// </returns>
-        public TypeAdapterSetter<TSource, TDestination> AfterMapping(
-            Action<TSource, TDestination, TDestination?> action)
+        public TypeAdapterSetter<TSource, TDestination> AfterMapping(Action<TSource, TDestination, TDestination?> action)
         {
             this.CheckCompiled();
 
@@ -788,8 +736,7 @@ namespace Mapster
             return this;
         }
 
-        public TypeAdapterSetter<TSource, TDestination> BeforeMappingInline(
-            Expression<Action<TSource, TDestination>> action)
+        public TypeAdapterSetter<TSource, TDestination> BeforeMappingInline(Expression<Action<TSource, TDestination>> action)
         {
             this.CheckCompiled();
 
@@ -808,8 +755,7 @@ namespace Mapster
         /// <returns>
         /// The current <see cref="TypeAdapterSetter{TSource, TDestination}"/> instance.
         /// </returns>
-        public TypeAdapterSetter<TSource, TDestination> BeforeMappingInline(
-            Expression<Action<TSource, TDestination, TDestination?>> action)
+        public TypeAdapterSetter<TSource, TDestination> BeforeMappingInline(Expression<Action<TSource, TDestination, TDestination?>> action)
         {
             this.CheckCompiled();
 
@@ -817,8 +763,7 @@ namespace Mapster
             return this;
         }
 
-        public TypeAdapterSetter<TSource, TDestination> AfterMappingInline(
-            Expression<Action<TSource, TDestination>> action)
+        public TypeAdapterSetter<TSource, TDestination> AfterMappingInline(Expression<Action<TSource, TDestination>> action)
         {
             this.CheckCompiled();
 
@@ -837,8 +782,7 @@ namespace Mapster
         /// <returns>
         /// The current <see cref="TypeAdapterSetter{TSource, TDestination}"/> instance.
         /// </returns>
-        public TypeAdapterSetter<TSource, TDestination> AfterMappingInline(
-            Expression<Action<TSource, TDestination, TDestination?>> action)
+        public TypeAdapterSetter<TSource, TDestination> AfterMappingInline(Expression<Action<TSource, TDestination, TDestination?>> action)
         {
             this.CheckCompiled();
 
@@ -847,8 +791,8 @@ namespace Mapster
         }
 
         public TypeAdapterSetter<TSource, TDestination> Include<TDerivedSource, TDerivedDestination>()
-            where TDerivedSource : class, TSource
-            where TDerivedDestination : class, TDestination
+            where TDerivedSource: class, TSource
+            where TDerivedDestination: class, TDestination
         {
             return this.Include(typeof(TDerivedSource), typeof(TDerivedDestination));
         }
@@ -864,14 +808,12 @@ namespace Mapster
                 throw new InvalidCastException("In order to use inherits, TSource must be inherited from TBaseSource.");
 
             if (!baseDestinationType.GetTypeInfo().IsAssignableFrom(typeof(TDestination).GetTypeInfo()))
-                throw new InvalidCastException(
-                    "In order to use inherits, TDestination must be inherited from TBaseDestination.");
+                throw new InvalidCastException("In order to use inherits, TDestination must be inherited from TBaseDestination.");
 
             if (Config.RuleMap.TryGetValue(new TypeTuple(baseSourceType, baseDestinationType), out var rule))
             {
                 Settings.Apply(rule.Settings);
             }
-
             return this;
         }
 
@@ -921,8 +863,7 @@ namespace Mapster
             DestinationToSourceSetter.Settings.SkipDestinationMemberCheck = true;
         }
 
-        public TwoWaysTypeAdapterSetter<TSource, TDestination> AddDestinationTransform<TDestinationMember>(
-            Expression<Func<TDestinationMember, TDestinationMember>> transform)
+        public TwoWaysTypeAdapterSetter<TSource, TDestination> AddDestinationTransform<TDestinationMember>(Expression<Func<TDestinationMember, TDestinationMember>> transform)
         {
             SourceToDestinationSetter.AddDestinationTransform(transform);
             if (typeof(TSource) != typeof(TDestination))
@@ -945,7 +886,6 @@ namespace Mapster
             {
                 DestinationToSourceSetter.IgnoreMember((model, _) => model.Name == name);
             }
-
             return this;
         }
 
@@ -963,21 +903,17 @@ namespace Mapster
             return this;
         }
 
-        public TwoWaysTypeAdapterSetter<TSource, TDestination> IgnoreMember(
-            Func<IMemberModel, MemberSide, bool> predicate)
+        public TwoWaysTypeAdapterSetter<TSource, TDestination> IgnoreMember(Func<IMemberModel, MemberSide, bool> predicate)
         {
             SourceToDestinationSetter.IgnoreMember(predicate);
-            DestinationToSourceSetter.IgnoreMember((model, side) =>
-                predicate(model, side == MemberSide.Source ? MemberSide.Destination : MemberSide.Source));
+            DestinationToSourceSetter.IgnoreMember((model, side) => predicate(model, side == MemberSide.Source ? MemberSide.Destination : MemberSide.Source));
             return this;
         }
 
-        public TwoWaysTypeAdapterSetter<TSource, TDestination> IncludeMember(
-            Func<IMemberModel, MemberSide, bool> predicate)
+        public TwoWaysTypeAdapterSetter<TSource, TDestination> IncludeMember(Func<IMemberModel, MemberSide, bool> predicate)
         {
             SourceToDestinationSetter.IncludeMember(predicate);
-            DestinationToSourceSetter.IncludeMember((model, side) =>
-                predicate(model, side == MemberSide.Source ? MemberSide.Destination : MemberSide.Source));
+            DestinationToSourceSetter.IncludeMember((model, side) => predicate(model, side == MemberSide.Source ? MemberSide.Destination : MemberSide.Source));
             return this;
         }
 
@@ -1029,8 +965,7 @@ namespace Mapster
             return this;
         }
 
-        public TwoWaysTypeAdapterSetter<TSource, TDestination> Map(string destinationMemberName,
-            string sourceMemberName)
+        public TwoWaysTypeAdapterSetter<TSource, TDestination> Map(string destinationMemberName, string sourceMemberName)
         {
             SourceToDestinationSetter.Map(destinationMemberName, sourceMemberName);
             DestinationToSourceSetter.Map(sourceMemberName, destinationMemberName);
@@ -1065,12 +1000,10 @@ namespace Mapster
             return this;
         }
 
-        public TwoWaysTypeAdapterSetter<TSource, TDestination> GetMemberName(
-            Func<IMemberModel, MemberSide, string?> func)
+        public TwoWaysTypeAdapterSetter<TSource, TDestination> GetMemberName(Func<IMemberModel, MemberSide, string?> func)
         {
             SourceToDestinationSetter.GetMemberName(func);
-            DestinationToSourceSetter.GetMemberName((model, side) =>
-                func(model, side == MemberSide.Source ? MemberSide.Destination : MemberSide.Source));
+            DestinationToSourceSetter.GetMemberName((model, side) => func(model, side == MemberSide.Source ? MemberSide.Destination : MemberSide.Source));
             return this;
         }
 
@@ -1081,15 +1014,13 @@ namespace Mapster
             return this;
         }
 
-        public TwoWaysTypeAdapterSetter<TSource, TDestination> Ignore(
-            params Expression<Func<TDestination, object>>[] members)
+        public TwoWaysTypeAdapterSetter<TSource, TDestination> Ignore(params Expression<Func<TDestination, object>>[] members)
         {
             foreach (var member in members)
             {
                 var path = member.GetMemberPath()!;
                 this.Ignore(path);
             }
-
             return this;
         }
 

--- a/src/Mapster/TypeAdapterSetter.cs
+++ b/src/Mapster/TypeAdapterSetter.cs
@@ -16,21 +16,25 @@ namespace Mapster
 
         public readonly TypeAdapterSettings Settings;
         public readonly TypeAdapterConfig Config;
+
         public TypeAdapterSetter(TypeAdapterSettings settings, TypeAdapterConfig config)
         {
             this.Settings = settings;
             this.Config = config;
         }
     }
+
     public static class TypeAdapterSetterExtensions
     {
         internal static void CheckCompiled<TSetter>(this TSetter setter) where TSetter : TypeAdapterSetter
         {
             if (setter.Settings.Compiled)
-                throw new InvalidOperationException("TypeAdapter.Adapt was already called, please clone or create new TypeAdapterConfig.");
+                throw new InvalidOperationException(
+                    "TypeAdapter.Adapt was already called, please clone or create new TypeAdapterConfig.");
         }
 
-        public static TSetter AddDestinationTransform<TSetter, TDestinationMember>(this TSetter setter, Expression<Func<TDestinationMember, TDestinationMember>> transform) where TSetter : TypeAdapterSetter
+        public static TSetter AddDestinationTransform<TSetter, TDestinationMember>(this TSetter setter,
+            Expression<Func<TDestinationMember, TDestinationMember>> transform) where TSetter : TypeAdapterSetter
         {
             setter.CheckCompiled();
 
@@ -42,7 +46,8 @@ namespace Mapster
             return setter;
         }
 
-        public static TSetter AddDestinationTransform<TSetter>(this TSetter setter, DestinationTransform transform) where TSetter : TypeAdapterSetter
+        public static TSetter AddDestinationTransform<TSetter>(this TSetter setter, DestinationTransform transform)
+            where TSetter : TypeAdapterSetter
         {
             setter.CheckCompiled();
 
@@ -50,7 +55,8 @@ namespace Mapster
             return setter;
         }
 
-        public static TSetter Ignore<TSetter>(this TSetter setter, params string[] names) where TSetter : TypeAdapterSetter
+        public static TSetter Ignore<TSetter>(this TSetter setter, params string[] names)
+            where TSetter : TypeAdapterSetter
         {
             setter.CheckCompiled();
 
@@ -58,32 +64,40 @@ namespace Mapster
             {
                 setter.Settings.Ignore[name] = new IgnoreDictionary.IgnoreItem();
             }
+
             return setter;
         }
 
-        public static TSetter IgnoreAttribute<TSetter>(this TSetter setter, params Type[] types) where TSetter : TypeAdapterSetter
+        public static TSetter IgnoreAttribute<TSetter>(this TSetter setter, params Type[] types)
+            where TSetter : TypeAdapterSetter
         {
             setter.CheckCompiled();
 
             foreach (var type in types)
             {
-                setter.Settings.ShouldMapMember.Add((member, _) => member.HasCustomAttribute(type) ? (bool?)false : null);
+                setter.Settings.ShouldMapMember.Add(
+                    (member, _) => member.HasCustomAttribute(type) ? (bool?)false : null);
             }
+
             return setter;
         }
 
-        public static TSetter IncludeAttribute<TSetter>(this TSetter setter, params Type[] types) where TSetter : TypeAdapterSetter
+        public static TSetter IncludeAttribute<TSetter>(this TSetter setter, params Type[] types)
+            where TSetter : TypeAdapterSetter
         {
             setter.CheckCompiled();
 
             foreach (var type in types)
             {
-                setter.Settings.ShouldMapMember.Add((member, _) => member.HasCustomAttribute(type) ? (bool?)true : null);
+                setter.Settings.ShouldMapMember.Add((member, _) =>
+                    member.HasCustomAttribute(type) ? (bool?)true : null);
             }
+
             return setter;
         }
 
-        public static TSetter IgnoreMember<TSetter>(this TSetter setter, Func<IMemberModel, MemberSide, bool> predicate) where TSetter : TypeAdapterSetter
+        public static TSetter IgnoreMember<TSetter>(this TSetter setter, Func<IMemberModel, MemberSide, bool> predicate)
+            where TSetter : TypeAdapterSetter
         {
             setter.CheckCompiled();
 
@@ -91,7 +105,8 @@ namespace Mapster
             return setter;
         }
 
-        public static TSetter IncludeMember<TSetter>(this TSetter setter, Func<IMemberModel, MemberSide, bool> predicate) where TSetter : TypeAdapterSetter
+        public static TSetter IncludeMember<TSetter>(this TSetter setter,
+            Func<IMemberModel, MemberSide, bool> predicate) where TSetter : TypeAdapterSetter
         {
             setter.CheckCompiled();
 
@@ -99,7 +114,8 @@ namespace Mapster
             return setter;
         }
 
-        public static TSetter ShallowCopyForSameType<TSetter>(this TSetter setter, bool value) where TSetter : TypeAdapterSetter
+        public static TSetter ShallowCopyForSameType<TSetter>(this TSetter setter, bool value)
+            where TSetter : TypeAdapterSetter
         {
             setter.CheckCompiled();
 
@@ -107,7 +123,8 @@ namespace Mapster
             return setter;
         }
 
-        public static TSetter EnumMappingStrategy<TSetter>(this TSetter setter, EnumMappingStrategy strategy) where TSetter : TypeAdapterSetter
+        public static TSetter EnumMappingStrategy<TSetter>(this TSetter setter, EnumMappingStrategy strategy)
+            where TSetter : TypeAdapterSetter
         {
             setter.CheckCompiled();
 
@@ -115,7 +132,8 @@ namespace Mapster
             return setter;
         }
 
-        public static TSetter IgnoreNullValues<TSetter>(this TSetter setter, bool value) where TSetter : TypeAdapterSetter
+        public static TSetter IgnoreNullValues<TSetter>(this TSetter setter, bool value)
+            where TSetter : TypeAdapterSetter
         {
             setter.CheckCompiled();
 
@@ -123,7 +141,8 @@ namespace Mapster
             return setter;
         }
 
-        public static TSetter PreserveReference<TSetter>(this TSetter setter, bool value) where TSetter : TypeAdapterSetter
+        public static TSetter PreserveReference<TSetter>(this TSetter setter, bool value)
+            where TSetter : TypeAdapterSetter
         {
             setter.CheckCompiled();
 
@@ -131,7 +150,8 @@ namespace Mapster
             return setter;
         }
 
-        public static TSetter NameMatchingStrategy<TSetter>(this TSetter setter, NameMatchingStrategy value) where TSetter : TypeAdapterSetter
+        public static TSetter NameMatchingStrategy<TSetter>(this TSetter setter, NameMatchingStrategy value)
+            where TSetter : TypeAdapterSetter
         {
             setter.CheckCompiled();
 
@@ -174,7 +194,8 @@ namespace Mapster
         }
 
         public static TSetter Map<TSetter>(
-            this TSetter setter, string destinationMemberName, string sourceMemberName) where TSetter : TypeAdapterSetter
+            this TSetter setter, string destinationMemberName, string sourceMemberName)
+            where TSetter : TypeAdapterSetter
         {
             setter.CheckCompiled();
 
@@ -188,7 +209,8 @@ namespace Mapster
             return setter;
         }
 
-        public static TSetter EnableNonPublicMembers<TSetter>(this TSetter setter, bool value) where TSetter : TypeAdapterSetter
+        public static TSetter EnableNonPublicMembers<TSetter>(this TSetter setter, bool value)
+            where TSetter : TypeAdapterSetter
         {
             setter.CheckCompiled();
 
@@ -196,7 +218,8 @@ namespace Mapster
             return setter;
         }
 
-        public static TSetter IgnoreNonMapped<TSetter>(this TSetter setter, bool value) where TSetter : TypeAdapterSetter
+        public static TSetter IgnoreNonMapped<TSetter>(this TSetter setter, bool value)
+            where TSetter : TypeAdapterSetter
         {
             setter.CheckCompiled();
 
@@ -204,7 +227,8 @@ namespace Mapster
             return setter;
         }
 
-        public static TSetter AvoidInlineMapping<TSetter>(this TSetter setter, bool value) where TSetter : TypeAdapterSetter
+        public static TSetter AvoidInlineMapping<TSetter>(this TSetter setter, bool value)
+            where TSetter : TypeAdapterSetter
         {
             setter.CheckCompiled();
 
@@ -212,7 +236,8 @@ namespace Mapster
             return setter;
         }
 
-        public static TSetter RequireDestinationMemberSource<TSetter>(this TSetter setter, bool value) where TSetter : TypeAdapterSetter
+        public static TSetter RequireDestinationMemberSource<TSetter>(this TSetter setter, bool value)
+            where TSetter : TypeAdapterSetter
         {
             setter.CheckCompiled();
 
@@ -220,7 +245,8 @@ namespace Mapster
             return setter;
         }
 
-        public static TSetter GetMemberName<TSetter>(this TSetter setter, Func<IMemberModel, string?> func) where TSetter : TypeAdapterSetter
+        public static TSetter GetMemberName<TSetter>(this TSetter setter, Func<IMemberModel, string?> func)
+            where TSetter : TypeAdapterSetter
         {
             setter.CheckCompiled();
 
@@ -228,7 +254,8 @@ namespace Mapster
             return setter;
         }
 
-        public static TSetter GetMemberName<TSetter>(this TSetter setter, Func<IMemberModel, MemberSide, string?> func) where TSetter : TypeAdapterSetter
+        public static TSetter GetMemberName<TSetter>(this TSetter setter, Func<IMemberModel, MemberSide, string?> func)
+            where TSetter : TypeAdapterSetter
         {
             setter.CheckCompiled();
 
@@ -236,7 +263,8 @@ namespace Mapster
             return setter;
         }
 
-        public static TSetter MapToConstructor<TSetter>(this TSetter setter, bool value) where TSetter : TypeAdapterSetter
+        public static TSetter MapToConstructor<TSetter>(this TSetter setter, bool value)
+            where TSetter : TypeAdapterSetter
         {
             setter.CheckCompiled();
 
@@ -260,7 +288,8 @@ namespace Mapster
             return setter;
         }
 
-        public static TSetter UseDestinationValue<TSetter>(this TSetter setter, Func<IMemberModel, bool> func) where TSetter : TypeAdapterSetter
+        public static TSetter UseDestinationValue<TSetter>(this TSetter setter, Func<IMemberModel, bool> func)
+            where TSetter : TypeAdapterSetter
         {
             setter.CheckCompiled();
 
@@ -268,7 +297,8 @@ namespace Mapster
             return setter;
         }
 
-        internal static TSetter Include<TSetter>(this TSetter setter, Type sourceType, Type destType) where TSetter : TypeAdapterSetter
+        internal static TSetter Include<TSetter>(this TSetter setter, Type sourceType, Type destType)
+            where TSetter : TypeAdapterSetter
         {
             setter.CheckCompiled();
 
@@ -276,7 +306,9 @@ namespace Mapster
             {
                 Priority = arg =>
                     arg.SourceType == sourceType &&
-                    arg.DestinationType == destType ? (int?)100 : null,
+                    arg.DestinationType == destType
+                        ? (int?)100
+                        : null,
                 Settings = setter.Settings
             });
 
@@ -285,7 +317,8 @@ namespace Mapster
             return setter;
         }
 
-        public static TSetter ApplyAdaptAttribute<TSetter>(this TSetter setter, BaseAdaptAttribute attr) where TSetter : TypeAdapterSetter
+        public static TSetter ApplyAdaptAttribute<TSetter>(this TSetter setter, BaseAdaptAttribute attr)
+            where TSetter : TypeAdapterSetter
         {
             if (attr.IgnoreAttributes != null)
                 setter.IgnoreAttribute(attr.IgnoreAttributes);
@@ -296,6 +329,7 @@ namespace Mapster
                     .Intersect(attr.IgnoreNoAttributes)
                     .Any());
             }
+
             if (attr.IgnoreNamespaces != null)
             {
                 foreach (var ns in attr.IgnoreNamespaces)
@@ -303,6 +337,7 @@ namespace Mapster
                     setter.IgnoreMember((member, _) => member.Type.Namespace?.StartsWith(ns) == true);
                 }
             }
+
             if (attr.MaxDepth > 0)
                 setter.MaxDepth(attr.MaxDepth);
             if (attr.GetBooleanSettingValues(nameof(attr.IgnoreNullValues)) != null)
@@ -323,7 +358,8 @@ namespace Mapster
     {
         internal TypeAdapterSetter(TypeAdapterSettings settings, TypeAdapterConfig parentConfig)
             : base(settings, parentConfig)
-        { }
+        {
+        }
 
         public TypeAdapterSetter<TDestination> Ignore(params Expression<Func<TDestination, object>>[] members)
         {
@@ -333,6 +369,7 @@ namespace Mapster
             {
                 Settings.Ignore[member.GetMemberPath()!] = new IgnoreDictionary.IgnoreItem();
             }
+
             return this;
         }
 
@@ -342,7 +379,7 @@ namespace Mapster
         {
             this.CheckCompiled();
 
-            var invoker = Expression.Lambda(source.Body, Expression.Parameter(typeof (object)));
+            var invoker = Expression.Lambda(source.Body, Expression.Parameter(typeof(object)));
             if (member.IsIdentity())
             {
                 Settings.ExtraSources.Add(invoker);
@@ -421,20 +458,21 @@ namespace Mapster
             return this;
         }
 
-        public TypeAdapterSetter<TDestination> MapToConstructor(ConstructorInfo ctor)
+        public TypeAdapterSetter<TDestination> MapToConstructor(ConstructorInfo? ctor)
         {
             this.CheckCompiled();
-
-            if (ctor != null)
+            Settings.MapToConstructor = ctor;
+            if (ctor == null)
             {
-                if (!typeof(TDestination).GetTypeInfo().IsAssignableFrom(ctor.DeclaringType!.GetTypeInfo()))
-                    throw new ArgumentException("Constructor cannot be assigned to type TDestination", nameof(ctor));
-
-                if (ctor.DeclaringType!.GetTypeInfo().IsAbstract)
-                    throw new ArgumentException("Constructor of abstract type cannot be created", nameof(ctor));
+                return this;
             }
 
-            this.Settings.MapToConstructor = ctor;
+            if (!typeof(TDestination).GetTypeInfo().IsAssignableFrom(ctor.DeclaringType!.GetTypeInfo()))
+                throw new ArgumentException("Constructor cannot be assigned to type TDestination", nameof(ctor));
+
+            if (ctor.DeclaringType!.GetTypeInfo().IsAbstract)
+                throw new ArgumentException("Constructor of abstract type cannot be created", nameof(ctor));
+
             return this;
         }
 
@@ -454,7 +492,7 @@ namespace Mapster
         {
             this.CheckCompiled();
 
-            var lambda = Expression.Lambda(action.Body, 
+            var lambda = Expression.Lambda(action.Body,
                 Expression.Parameter(typeof(object), SourceParameterName),
                 action.Parameters[0]);
             Settings.AfterMappingFactories.Add(arg => lambda);
@@ -462,16 +500,19 @@ namespace Mapster
         }
     }
 
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Minor Code Smell", "S4136:Method overloads should be grouped together", Justification = "<Pending>")]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Minor Code Smell",
+        "S4136:Method overloads should be grouped together", Justification = "<Pending>")]
     public class TypeAdapterSetter<TSource, TDestination> : TypeAdapterSetter<TDestination>
     {
         internal TypeAdapterSetter(TypeAdapterSettings settings, TypeAdapterConfig parentConfig)
             : base(settings, parentConfig)
-        { }
+        {
+        }
 
         #region replace for chaining
 
-        public new TypeAdapterSetter<TSource, TDestination> Ignore(params Expression<Func<TDestination, object>>[] members)
+        public new TypeAdapterSetter<TSource, TDestination> Ignore(
+            params Expression<Func<TDestination, object>>[] members)
         {
             return (TypeAdapterSetter<TSource, TDestination>)base.Ignore(members);
         }
@@ -490,7 +531,8 @@ namespace Mapster
             return (TypeAdapterSetter<TSource, TDestination>)base.Map(destinationMember, sourceMemberName);
         }
 
-        public new TypeAdapterSetter<TSource, TDestination> ConstructUsing(Expression<Func<TDestination>> constructUsing)
+        public new TypeAdapterSetter<TSource, TDestination> ConstructUsing(
+            Expression<Func<TDestination>> constructUsing)
         {
             return (TypeAdapterSetter<TSource, TDestination>)base.ConstructUsing(constructUsing);
         }
@@ -507,7 +549,7 @@ namespace Mapster
 
         public new TypeAdapterSetter<TSource, TDestination> MapToConstructor(ConstructorInfo ctor)
         {
-            return (TypeAdapterSetter<TSource, TDestination>) base.MapToConstructor(ctor);
+            return (TypeAdapterSetter<TSource, TDestination>)base.MapToConstructor(ctor);
         }
 
         public new TypeAdapterSetter<TSource, TDestination> BeforeMappingInline(Expression<Action<TDestination>> action)
@@ -517,7 +559,7 @@ namespace Mapster
 
         public new TypeAdapterSetter<TSource, TDestination> AfterMappingInline(Expression<Action<TDestination>> action)
         {
-            return (TypeAdapterSetter<TSource, TDestination>) base.AfterMappingInline(action);
+            return (TypeAdapterSetter<TSource, TDestination>)base.AfterMappingInline(action);
         }
 
         #endregion
@@ -533,6 +575,7 @@ namespace Mapster
                 var name = member.GetMemberPath()!;
                 Settings.Ignore.Merge(name, new IgnoreDictionary.IgnoreItem(condition, false));
             }
+
             return this;
         }
 
@@ -546,6 +589,7 @@ namespace Mapster
             {
                 Settings.Ignore.Merge(member, new IgnoreDictionary.IgnoreItem(condition, false));
             }
+
             return this;
         }
 
@@ -589,7 +633,8 @@ namespace Mapster
             return this;
         }
 
-        public TypeAdapterSetter<TSource, TDestination> ConstructUsing(Expression<Func<TSource, TDestination>> constructUsing)
+        public TypeAdapterSetter<TSource, TDestination> ConstructUsing(
+            Expression<Func<TSource, TDestination>> constructUsing)
         {
             this.CheckCompiled();
 
@@ -598,7 +643,8 @@ namespace Mapster
             return this;
         }
 
-        public TypeAdapterSetter<TSource, TDestination> ConstructUsing(Expression<Func<TSource, TDestination?, TDestination>> constructUsing)
+        public TypeAdapterSetter<TSource, TDestination> ConstructUsing(
+            Expression<Func<TSource, TDestination?, TDestination>> constructUsing)
         {
             this.CheckCompiled();
 
@@ -607,7 +653,8 @@ namespace Mapster
             return this;
         }
 
-        public TypeAdapterSetter<TSource, TDestination> MapWith(Expression<Func<TSource, TDestination>> converterFactory, bool applySettings = false)
+        public TypeAdapterSetter<TSource, TDestination> MapWith(
+            Expression<Func<TSource, TDestination>> converterFactory, bool applySettings = false)
         {
             this.CheckCompiled();
 
@@ -623,14 +670,16 @@ namespace Mapster
                 if (Settings.ConverterToTargetFactory == null)
                 {
                     var dest = Expression.Parameter(typeof(TDestination));
-                    Settings.ConverterToTargetFactory = arg => Expression.Lambda(converterFactory.Body, converterFactory.Parameters[0], dest);
+                    Settings.ConverterToTargetFactory = arg =>
+                        Expression.Lambda(converterFactory.Body, converterFactory.Parameters[0], dest);
                 }
             }
 
             return this;
         }
 
-        public TypeAdapterSetter<TSource, TDestination> MapToTargetWith(Expression<Func<TSource, TDestination, TDestination>> converterFactory, bool applySettings = false)
+        public TypeAdapterSetter<TSource, TDestination> MapToTargetWith(
+            Expression<Func<TSource, TDestination, TDestination>> converterFactory, bool applySettings = false)
         {
             this.CheckCompiled();
 
@@ -641,6 +690,7 @@ namespace Mapster
             }
             else
                 Settings.ConverterToTargetFactory = arg => converterFactory;
+
             return this;
         }
 
@@ -671,7 +721,8 @@ namespace Mapster
         /// <returns>
         /// The current <see cref="TypeAdapterSetter{TSource, TDestination}"/> instance.
         /// </returns>
-        public TypeAdapterSetter<TSource, TDestination> BeforeMapping(Action<TSource, TDestination, TDestination?> action)
+        public TypeAdapterSetter<TSource, TDestination> BeforeMapping(
+            Action<TSource, TDestination, TDestination?> action)
         {
             this.CheckCompiled();
 
@@ -717,7 +768,8 @@ namespace Mapster
         /// <returns>
         /// The current <see cref="TypeAdapterSetter{TSource, TDestination}"/> instance.
         /// </returns>
-        public TypeAdapterSetter<TSource, TDestination> AfterMapping(Action<TSource, TDestination, TDestination?> action)
+        public TypeAdapterSetter<TSource, TDestination> AfterMapping(
+            Action<TSource, TDestination, TDestination?> action)
         {
             this.CheckCompiled();
 
@@ -736,7 +788,8 @@ namespace Mapster
             return this;
         }
 
-        public TypeAdapterSetter<TSource, TDestination> BeforeMappingInline(Expression<Action<TSource, TDestination>> action)
+        public TypeAdapterSetter<TSource, TDestination> BeforeMappingInline(
+            Expression<Action<TSource, TDestination>> action)
         {
             this.CheckCompiled();
 
@@ -755,7 +808,8 @@ namespace Mapster
         /// <returns>
         /// The current <see cref="TypeAdapterSetter{TSource, TDestination}"/> instance.
         /// </returns>
-        public TypeAdapterSetter<TSource, TDestination> BeforeMappingInline(Expression<Action<TSource, TDestination, TDestination?>> action)
+        public TypeAdapterSetter<TSource, TDestination> BeforeMappingInline(
+            Expression<Action<TSource, TDestination, TDestination?>> action)
         {
             this.CheckCompiled();
 
@@ -763,7 +817,8 @@ namespace Mapster
             return this;
         }
 
-        public TypeAdapterSetter<TSource, TDestination> AfterMappingInline(Expression<Action<TSource, TDestination>> action)
+        public TypeAdapterSetter<TSource, TDestination> AfterMappingInline(
+            Expression<Action<TSource, TDestination>> action)
         {
             this.CheckCompiled();
 
@@ -782,7 +837,8 @@ namespace Mapster
         /// <returns>
         /// The current <see cref="TypeAdapterSetter{TSource, TDestination}"/> instance.
         /// </returns>
-        public TypeAdapterSetter<TSource, TDestination> AfterMappingInline(Expression<Action<TSource, TDestination, TDestination?>> action)
+        public TypeAdapterSetter<TSource, TDestination> AfterMappingInline(
+            Expression<Action<TSource, TDestination, TDestination?>> action)
         {
             this.CheckCompiled();
 
@@ -791,8 +847,8 @@ namespace Mapster
         }
 
         public TypeAdapterSetter<TSource, TDestination> Include<TDerivedSource, TDerivedDestination>()
-            where TDerivedSource: class, TSource
-            where TDerivedDestination: class, TDestination
+            where TDerivedSource : class, TSource
+            where TDerivedDestination : class, TDestination
         {
             return this.Include(typeof(TDerivedSource), typeof(TDerivedDestination));
         }
@@ -808,12 +864,14 @@ namespace Mapster
                 throw new InvalidCastException("In order to use inherits, TSource must be inherited from TBaseSource.");
 
             if (!baseDestinationType.GetTypeInfo().IsAssignableFrom(typeof(TDestination).GetTypeInfo()))
-                throw new InvalidCastException("In order to use inherits, TDestination must be inherited from TBaseDestination.");
+                throw new InvalidCastException(
+                    "In order to use inherits, TDestination must be inherited from TBaseDestination.");
 
             if (Config.RuleMap.TryGetValue(new TypeTuple(baseSourceType, baseDestinationType), out var rule))
             {
                 Settings.Apply(rule.Settings);
             }
+
             return this;
         }
 
@@ -863,7 +921,8 @@ namespace Mapster
             DestinationToSourceSetter.Settings.SkipDestinationMemberCheck = true;
         }
 
-        public TwoWaysTypeAdapterSetter<TSource, TDestination> AddDestinationTransform<TDestinationMember>(Expression<Func<TDestinationMember, TDestinationMember>> transform)
+        public TwoWaysTypeAdapterSetter<TSource, TDestination> AddDestinationTransform<TDestinationMember>(
+            Expression<Func<TDestinationMember, TDestinationMember>> transform)
         {
             SourceToDestinationSetter.AddDestinationTransform(transform);
             if (typeof(TSource) != typeof(TDestination))
@@ -886,6 +945,7 @@ namespace Mapster
             {
                 DestinationToSourceSetter.IgnoreMember((model, _) => model.Name == name);
             }
+
             return this;
         }
 
@@ -903,17 +963,21 @@ namespace Mapster
             return this;
         }
 
-        public TwoWaysTypeAdapterSetter<TSource, TDestination> IgnoreMember(Func<IMemberModel, MemberSide, bool> predicate)
+        public TwoWaysTypeAdapterSetter<TSource, TDestination> IgnoreMember(
+            Func<IMemberModel, MemberSide, bool> predicate)
         {
             SourceToDestinationSetter.IgnoreMember(predicate);
-            DestinationToSourceSetter.IgnoreMember((model, side) => predicate(model, side == MemberSide.Source ? MemberSide.Destination : MemberSide.Source));
+            DestinationToSourceSetter.IgnoreMember((model, side) =>
+                predicate(model, side == MemberSide.Source ? MemberSide.Destination : MemberSide.Source));
             return this;
         }
 
-        public TwoWaysTypeAdapterSetter<TSource, TDestination> IncludeMember(Func<IMemberModel, MemberSide, bool> predicate)
+        public TwoWaysTypeAdapterSetter<TSource, TDestination> IncludeMember(
+            Func<IMemberModel, MemberSide, bool> predicate)
         {
             SourceToDestinationSetter.IncludeMember(predicate);
-            DestinationToSourceSetter.IncludeMember((model, side) => predicate(model, side == MemberSide.Source ? MemberSide.Destination : MemberSide.Source));
+            DestinationToSourceSetter.IncludeMember((model, side) =>
+                predicate(model, side == MemberSide.Source ? MemberSide.Destination : MemberSide.Source));
             return this;
         }
 
@@ -965,7 +1029,8 @@ namespace Mapster
             return this;
         }
 
-        public TwoWaysTypeAdapterSetter<TSource, TDestination> Map(string destinationMemberName, string sourceMemberName)
+        public TwoWaysTypeAdapterSetter<TSource, TDestination> Map(string destinationMemberName,
+            string sourceMemberName)
         {
             SourceToDestinationSetter.Map(destinationMemberName, sourceMemberName);
             DestinationToSourceSetter.Map(sourceMemberName, destinationMemberName);
@@ -1000,10 +1065,12 @@ namespace Mapster
             return this;
         }
 
-        public TwoWaysTypeAdapterSetter<TSource, TDestination> GetMemberName(Func<IMemberModel, MemberSide, string?> func)
+        public TwoWaysTypeAdapterSetter<TSource, TDestination> GetMemberName(
+            Func<IMemberModel, MemberSide, string?> func)
         {
             SourceToDestinationSetter.GetMemberName(func);
-            DestinationToSourceSetter.GetMemberName((model, side) => func(model, side == MemberSide.Source ? MemberSide.Destination : MemberSide.Source));
+            DestinationToSourceSetter.GetMemberName((model, side) =>
+                func(model, side == MemberSide.Source ? MemberSide.Destination : MemberSide.Source));
             return this;
         }
 
@@ -1014,13 +1081,15 @@ namespace Mapster
             return this;
         }
 
-        public TwoWaysTypeAdapterSetter<TSource, TDestination> Ignore(params Expression<Func<TDestination, object>>[] members)
+        public TwoWaysTypeAdapterSetter<TSource, TDestination> Ignore(
+            params Expression<Func<TDestination, object>>[] members)
         {
             foreach (var member in members)
             {
                 var path = member.GetMemberPath()!;
                 this.Ignore(path);
             }
+
             return this;
         }
 

--- a/src/Mapster/Utils/ReflectionUtils.cs
+++ b/src/Mapster/Utils/ReflectionUtils.cs
@@ -374,5 +374,15 @@ namespace Mapster
                 type = type.GetTypeInfo().BaseType;
             } while (type != null && type != typeof(object));
         }
+        
+        public static bool IsInitOnly(this PropertyInfo propertyInfo)
+        {
+            var setMethod = propertyInfo.SetMethod;
+            if (setMethod == null)
+                return false;
+
+            var isExternalInitType = typeof(System.Runtime.CompilerServices.IsExternalInit);
+            return setMethod.ReturnParameter.GetRequiredCustomModifiers().Contains(isExternalInitType);
+        }
     }
 }


### PR DESCRIPTION
I've fixed [#536](https://github.com/MapsterMapper/Mapster/issues/536) and wrote a test that regenerates the exact issue
The test has been passed
I add a method to "ClassAdapter" in [this commit](https://github.com/MapsterMapper/Mapster/commit/f3df57c56841cf6230727f5e2ddf5d73e0c33fa8) to generate reflection code for setting init only properties

The result is like this:
```csharp
public _UserDto MapTo(_User p3, _UserDto p4)
        {
            if (p3 == null)
            {
                return null;
            }
            _UserDto result = p4 ?? new _UserDto();
            
            typeof(_UserDto).GetProperty("Id").SetValue(result, (object)p3.Id);
            typeof(_UserDto).GetProperty("Name").SetValue(result, p3.Name);
            return result;
            
        }
```
* I did not update the package version in csproj
