### PR TITLE
🐛 fix(TypeAdapter.cs): Make source parameter nullable

### DIFF
--- a/src/Mapster/TypeAdapter.cs
+++ b/src/Mapster/TypeAdapter.cs
@@ -21,7 +21,7 @@ namespace Mapster
         /// <typeparam name="TDestination">Destination type.</typeparam>
         /// <param name="source">Source object to adapt.</param>
         /// <returns>Adapted destination type.</returns>
-        public static TDestination Adapt<TDestination>(this object source)
+        public static TDestination Adapt<TDestination>(this object? source)
         {
             return Adapt<TDestination>(source, TypeAdapterConfig.GlobalSettings);
         }
@@ -33,7 +33,7 @@ namespace Mapster
         /// <param name="source">Source object to adapt.</param>
         /// <param name="config">Configuration</param>
         /// <returns>Adapted destination type.</returns>
-        public static TDestination Adapt<TDestination>(this object source, TypeAdapterConfig config)
+        public static TDestination Adapt<TDestination>(this object? source, TypeAdapterConfig config)
         {
             // ReSharper disable once ConditionIsAlwaysTrueOrFalse
             if (source == null)


### PR DESCRIPTION
# Changes
* The source parameter in the Adapt method is now nullable, which allows for null values to be passed in without throwing a null reference exception. This improves the robustness of the code and makes it more defensive against unexpected null values.

@eswann @chaowlert @chaowlert @satano 