### PR TITLE
Fix MapsterMapper#370 where capitalized abbreviations are not mapped …

### DIFF
--- a/src/Mapster.Tests/WhenMappingRecordTypes.cs
+++ b/src/Mapster.Tests/WhenMappingRecordTypes.cs
@@ -37,6 +37,19 @@ namespace Mapster.Tests
             dest.Age.ShouldBe(10);
         }
 
+        [TestMethod]
+        public void Map_RecordType_CapitalizationChanged()
+        {
+            TypeAdapterConfig<RecordType, RecordTypeDto>.NewConfig()
+                .Map(dest => dest.SpecialID, src => src.Id)
+                .Compile();
+
+            var source = new RecordType(Guid.NewGuid(), DayOfWeek.Monday);
+            var dest = source.Adapt<RecordTypeDto>();
+
+            dest.SpecialID.ShouldBe(source.Id);
+        }
+
         public class SimplePoco
         {
             public Guid Id { get; set; }
@@ -49,7 +62,7 @@ namespace Mapster.Tests
             public string Name { get; set; }
         }
 
-        public class RecordType
+        public record RecordType
         {
             public RecordType(Guid id, DayOfWeek day, string name = "foo", int age = 10)
             {
@@ -64,5 +77,7 @@ namespace Mapster.Tests
             public int Age { get; }
             public DayOfWeek Day { get; }
         }
+
+        public record RecordTypeDto(Guid SpecialID);
     }
 }

--- a/src/Mapster/Settings/ValueAccessingStrategy.cs
+++ b/src/Mapster/Settings/ValueAccessingStrategy.cs
@@ -36,7 +36,7 @@ namespace Mapster
             Expression? getter = null;
             foreach (var resolver in resolvers)
             {
-                if (!destinationMember.Name.Equals(resolver.DestinationMemberName))
+                if (!destinationMember.Name.Equals(resolver.DestinationMemberName, StringComparison.InvariantCultureIgnoreCase))
                     continue;
 
                 var invoke = resolver.GetInvokingExpression(source, arg.MapType);


### PR DESCRIPTION
…properly between records

This PR fixes an issue where when you have a destination member that isn't in pascal case for a record, then it will ignore the mapping. (#370) 

In `ValueAccessingStrategy.cs`, the custom resolver destination member is compared for equality against the ParameterModel destination member. However, in ParameterModel, it modifies the destination member to force it to be Pascal Case. I couldn't figure out exactly why we do this, but it breaks a number of tests if you change it. 

The only solution I could find that avoids breaking any tests is to compare the two destination members ignoring case. Even if this isn't the correct solution, hopefully this will help someone more familiar create a better solution.