### PR TITLE
Reversing execution order of Before/AfterMapping

### DIFF
--- a/src/Mapster.Tests/WhenPerformingAfterMapping.cs
+++ b/src/Mapster.Tests/WhenPerformingAfterMapping.cs
@@ -16,6 +16,10 @@ namespace Mapster.Tests
         [TestMethod]
         public void After_Mapping()
         {
+            TypeAdapterConfig<SimplePocoBaseBase, SimpleDto>.NewConfig()
+                .AfterMapping((src, dest) => dest.Name += "!!!");
+            TypeAdapterConfig<SimplePocoBase, SimpleDto>.NewConfig()
+                .AfterMapping((src, dest) => dest.Name += "***");
             TypeAdapterConfig<SimplePoco, SimpleDto>.NewConfig()
                 .AfterMapping((src, dest) => dest.Name += "xxx");
 
@@ -27,7 +31,7 @@ namespace Mapster.Tests
             var result = TypeAdapter.Adapt<SimpleDto>(poco);
 
             result.Id.ShouldBe(poco.Id);
-            result.Name.ShouldBe(poco.Name + "xxx");
+            result.Name.ShouldBe(poco.Name + "!!!***xxx");
         }
 
         [TestMethod]
@@ -95,10 +99,17 @@ namespace Mapster.Tests
             void Validate();
         }
 
-        public class SimplePoco
+        public class SimplePocoBaseBase
+        {
+            public string Name { get; set; }
+        }
+        public class SimplePocoBase : SimplePocoBaseBase
+        {
+        }
+
+        public class SimplePoco : SimplePocoBase
         {
             public Guid Id { get; set; }
-            public string Name { get; set; }
         }
 
         public class SimpleDto : IValidatable

--- a/src/Mapster.Tests/WhenPerformingBeforeMapping.cs
+++ b/src/Mapster.Tests/WhenPerformingBeforeMapping.cs
@@ -15,6 +15,25 @@ namespace Mapster.Tests
         }
 
         [TestMethod]
+        public void MapToType_Support_CorrectInheritanceOrder()
+        {
+            TypeAdapterConfig<SimplePocoBase, SimpleDto>.NewConfig()
+                .BeforeMapping((src, result) => result.Type = $"{src.Name}!!!");
+            TypeAdapterConfig<SimplePoco, SimpleDto>.NewConfig()
+                .BeforeMapping((src, result) => result.Type += "xxx");
+
+            var poco = new SimplePoco
+            {
+                Id = Guid.NewGuid(),
+                Name = "test",
+            };
+            var result = TypeAdapter.Adapt<SimpleDto>(poco);
+            result.Id.ShouldBe(poco.Id);
+            result.Name.ShouldBe(poco.Name);
+            result.Type.ShouldBe($"{poco.Name}!!!xxx");
+        }
+
+        [TestMethod]
         public void MapToType_Support_Destination_Parameter()
         {
             TypeAdapterConfig<SimplePoco, SimpleDto>.NewConfig()
@@ -25,7 +44,7 @@ namespace Mapster.Tests
                 Id = Guid.NewGuid(),
                 Name = "test",
             };
-            
+
             // check expression is successfully compiled
             Assert.ThrowsException<NullReferenceException>(() => poco.Adapt<SimpleDto>());
         }
@@ -55,16 +74,21 @@ namespace Mapster.Tests
             result.ShouldBe(new List<int> { 0, 1, 2, 3, });
         }
 
-        public class SimplePoco
+        public class SimplePocoBase
+        {
+            public string Name { get; set; }
+        }
+
+        public class SimplePoco : SimplePocoBase
         {
             public Guid Id { get; set; }
-            public string Name { get; set; }
         }
 
         public class SimpleDto
         {
             public Guid Id { get; set; }
             public string Name { get; set; }
+            public string Type { get; set; }
         }
     }
 }

--- a/src/Mapster/Adapters/BaseAdapter.cs
+++ b/src/Mapster/Adapters/BaseAdapter.cs
@@ -238,7 +238,7 @@ namespace Mapster.Adapters
                 assignActions.Add(assign);
 
                 //before(source, result, destination);
-                var beforeMappings = arg.Settings.BeforeMappingFactories.Select(it => InvokeMapping(it, source, result, destination, arg, true));
+                var beforeMappings = arg.Settings.BeforeMappingFactories.Select(it => InvokeMapping(it, source, result, destination, arg, true)).Reverse();
                 assignActions.AddRange(beforeMappings);
 
                 //result.prop = adapt(source.prop);
@@ -246,7 +246,7 @@ namespace Mapster.Adapters
                 var settingActions = new List<Expression> {mapping};
 
                 //after(source, result, destination);
-                var afterMappings = arg.Settings.AfterMappingFactories.Select(it => InvokeMapping(it, source, result, destination, arg, false));
+                var afterMappings = arg.Settings.AfterMappingFactories.Select(it => InvokeMapping(it, source, result, destination, arg, false)).Reverse();
                 settingActions.AddRange(afterMappings);
 
                 //return result;


### PR DESCRIPTION
This PR fixes #602 

`BeforeMappingFactories` and `AfterMappingFactories` execution order has been reversed to execute methods from base classes first