### PR TITLE
Not using shallow copy if mapping rule exists

### DIFF
--- a/src/Mapster.Tests/WhenSettingMapToTargetWith.cs
+++ b/src/Mapster.Tests/WhenSettingMapToTargetWith.cs
@@ -17,11 +17,38 @@ namespace Mapster.Tests
             var a = new Foo { A = 1 };
             var b = new Bar { A = 2 };
 
-            //This will not work as expected => b.A will be 1, ignoring the mapping defined
             var config = new TypeAdapterConfig();
+            config.Default.ShallowCopyForSameType(true);
+
             config.NewConfig<double, double>().MapToTargetWith((x, y) => 5);
             a.Adapt(b, config);
             b.A.ShouldBe(5);
+        }
+
+        [TestMethod]
+        public void MapWith_Should_Work_With_Adapt_To_Target()
+        {
+            var a = new List<double> {1, 2, 3};
+
+            var config = new TypeAdapterConfig();
+            config.Default.ShallowCopyForSameType(true);
+
+            config.NewConfig<double, double>().MapWith(_ => 5);
+            var b = a.Adapt<List<double>>(config);
+            b.ShouldBe(new List<double>{ 5, 5, 5});
+        }
+
+        [TestMethod]
+        public void MapWith_Should_Work_With_Adapt_To_Target_For_Collection()
+        {
+            var a = new List<double> {1, 2, 3};
+
+            var config = new TypeAdapterConfig();
+            config.Default.ShallowCopyForSameType(true);
+
+            config.NewConfig<List<double>, List<double>>().MapWith(_ => new List<double>{ 5, 5, 5});
+            var b = a.Adapt<List<double>>(config);
+            b.ShouldBe(new List<double>{ 5, 5, 5});
         }
 
         internal class Foo

--- a/src/Mapster/Adapters/BaseAdapter.cs
+++ b/src/Mapster/Adapters/BaseAdapter.cs
@@ -455,7 +455,8 @@ namespace Mapster.Adapters
 
             //adapt(source);
             var notUsingDestinationValue = mapping is not { UseDestinationValue: true };
-            var exp = source.Type == destinationType && arg.Settings.ShallowCopyForSameType == true && notUsingDestinationValue
+            var exp = source.Type == destinationType && arg.Settings.ShallowCopyForSameType == true && notUsingDestinationValue &&
+                      !arg.Context.Config.HasRuleFor(source.Type, destinationType)
                 ? source
                 : CreateAdaptExpressionCore(source, destinationType, arg, mapping, destination);
 

--- a/src/Mapster/Utils/TypeAdapterConfigExtensions.cs
+++ b/src/Mapster/Utils/TypeAdapterConfigExtensions.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using Mapster.Models;
 
 namespace Mapster.Utils;
 
@@ -27,4 +28,7 @@ public static class TypeAdapterConfigExtensions
         InterfaceDynamicMapper dynamicMapper = new(config, types);
         dynamicMapper.ApplyMappingFromAssembly();
     }
+
+    public static bool HasRuleFor(this TypeAdapterConfig config, Type srcType, Type dstType) =>
+        config.RuleMap.ContainsKey(new TypeTuple(srcType, dstType));
 }


### PR DESCRIPTION
This PR fixes #628 

Added checking if a mapping conversion is defined for desired type