### PR TITLE
New Record detection - Adapt To Class not create new instance

### DIFF
--- a/src/Mapster.Tests/WhenIgnoringConditionally.cs
+++ b/src/Mapster.Tests/WhenIgnoringConditionally.cs
@@ -160,6 +160,7 @@ namespace Mapster.Tests
         public void IgnoreIf_Apply_To_RecordType()
         {
             TypeAdapterConfig<SimplePoco, SimpleRecord>.NewConfig()
+                .EnableNonPublicMembers(true) // add or
                 .IgnoreIf((src, dest) => src.Name == "TestName", dest => dest.Name)
                 .Compile();
 
@@ -187,7 +188,7 @@ namespace Mapster.Tests
             public string Name { get; set; }
         }
 
-        public class SimpleRecord
+        public class SimpleRecord // or Replace on record
         {
             public int Id { get; }
             public string Name { get; }

--- a/src/Mapster.Tests/WhenRecordRegration.cs
+++ b/src/Mapster.Tests/WhenRecordRegration.cs
@@ -15,7 +15,7 @@ namespace Mapster.Tests
 
 
         [TestMethod]
-        public void AdaptRecord()
+        public void AdaptRecordToRecord()
         {
             var _sourse = new TestREcord() { X = 700 };
 
@@ -23,35 +23,50 @@ namespace Mapster.Tests
 
             var _result = _sourse.Adapt(_destination);
 
+
+
+            _result.X.ShouldBe(700);
+
             object.ReferenceEquals(_result, _destination).ShouldBeFalse();
+        }
 
-
+        [TestMethod]
+        public void AdaptPositionalRecordToPositionalRecord()
+        {
             var _sourcePositional = new TestRecordPositional(600);
 
             var _destinationPositional = new TestRecordPositional(900);
 
             var _positionalResult = _sourcePositional.Adapt(_destinationPositional);
 
+
+
+            _positionalResult.X.ShouldBe(600);
+
             object.ReferenceEquals(_destinationPositional, _positionalResult).ShouldBeFalse();
 
+        }
 
-
-
+        [TestMethod]
+        public void AdaptRecordStructToRecordStruct()
+        {
             var _sourceStruct = new TestRecordStruct() { X = 1000 };
 
             var _destinationStruct = new TestRecordStruct() { X = 800 };
 
             var _structResult = _sourceStruct.Adapt(_destinationStruct);
 
-            object.ReferenceEquals(_destinationPositional, _positionalResult).ShouldBeFalse();
 
-
-            _result.X.ShouldBe(700);
-
-            _positionalResult.X.ShouldBe(600);
 
             _structResult.X.ShouldBe(1000);
+
+            object.ReferenceEquals(_destinationStruct, _structResult).ShouldBeFalse();
+
+
         }
+
+
+
 
 
         [TestMethod]
@@ -64,11 +79,14 @@ namespace Mapster.Tests
             var _result = _sourse.Adapt(_destination);
 
 
-            object.ReferenceEquals(_destination, _result).ShouldBeTrue();
+
 
             _destination.ShouldBeOfType<TestClassProtectedCtr>();
 
             _destination.X.ShouldBe(200);
+
+
+            object.ReferenceEquals(_destination, _result).ShouldBeTrue();
         }
 
         [TestMethod]
@@ -81,11 +99,14 @@ namespace Mapster.Tests
             var _result = _sourse.Adapt(_destination);
 
 
-            object.ReferenceEquals(_destination, _result).ShouldBeFalse();
+
 
             _destination.ShouldBeOfType<TestRecordPositional>();
 
             _result.X.ShouldBe(200);
+
+
+            object.ReferenceEquals(_destination, _result).ShouldBeFalse();
         }
 
 
@@ -93,7 +114,28 @@ namespace Mapster.Tests
 
 
         [TestMethod]
-        public void AdaptClassIsNotNewInstanse()
+        public void AdaptClassToClassPublicCtr_IsNotInstanse()
+        {
+            var _sourse = new TestClassPublicCtr(200);
+
+            var _destination = new TestClassPublicCtr(400);
+
+            var _result = _sourse.Adapt(_destination);
+
+
+
+
+            _destination.ShouldBeOfType<TestClassPublicCtr>();
+
+            _destination.X.ShouldBe(200);
+
+
+            object.ReferenceEquals(_destination, _result).ShouldBeTrue();
+        }
+
+
+        [TestMethod]
+        public void AdaptClassToClassProtectdCtr_IsNotInstanse()
         {
             var _sourse = new TestClassPublicCtr(200);
 
@@ -102,12 +144,23 @@ namespace Mapster.Tests
             var _result = _sourse.Adapt(_destination);
 
 
-            object.ReferenceEquals(_destination, _result).ShouldBeTrue();
+
 
             _destination.ShouldBeOfType<TestClassProtectedCtr>();
 
             _destination.X.ShouldBe(200);
+
+
+            object.ReferenceEquals(_destination, _result).ShouldBeTrue();
         }
+
+
+
+
+
+
+
+
 
         /// <summary>
         /// https://github.com/MapsterMapper/Mapster/issues/615
@@ -136,7 +189,7 @@ namespace Mapster.Tests
         /// https://github.com/MapsterMapper/Mapster/issues/482
         /// </summary>
         [TestMethod]
-        public void AdaptClassIsPrivateProperty()
+        public void AdaptClassToClassFromPrivateProperty_IsNotInstanse()
         {
             var _sourse = new TestClassPublicCtr(200);
 
@@ -145,13 +198,16 @@ namespace Mapster.Tests
             var _result = _sourse.Adapt(_destination);
 
 
-            object.ReferenceEquals(_destination, _result).ShouldBeTrue();
+
 
             _destination.ShouldBeOfType<TestClassProtectedCtrPrivateProperty>();
 
             _destination.X.ShouldBe(200);
 
             _destination.Name.ShouldBe("Me");
+
+
+            object.ReferenceEquals(_destination, _result).ShouldBeTrue();
         }
 
 
@@ -214,21 +270,17 @@ namespace Mapster.Tests
 
 
 
+        #region NowNotWorking
 
+    //    [TestMethod]
+    //public void DetectFakeRecord()
+    //{
+    //    var _sourse = new TestClassPublicCtr(200);
 
+    //    var _destination = new FakeRecord { X = 300 };
 
-
-    #region NowNotWorking
-
-    [TestMethod]
-    public void DetectFakeRecord()
-    {
-        var _sourse = new TestClassPublicCtr(200);
-
-        var _destination = new FakeRecord { X = 300 };
-
-        var _result = _sourse.Adapt(_destination);
-    }
+    //    var _result = _sourse.Adapt(_destination);
+    //}
 
 
     /// <summary>

--- a/src/Mapster.Tests/WhenRecordRegration.cs
+++ b/src/Mapster.Tests/WhenRecordRegration.cs
@@ -211,7 +211,7 @@ namespace Mapster.Tests
 
         }
 
-    }
+
 
 
 
@@ -220,7 +220,15 @@ namespace Mapster.Tests
 
     #region NowNotWorking
 
+    [TestMethod]
+    public void DetectFakeRecord()
+    {
+        var _sourse = new TestClassPublicCtr(200);
 
+        var _destination = new FakeRecord { X = 300 };
+
+        var _result = _sourse.Adapt(_destination);
+    }
 
 
     /// <summary>
@@ -268,22 +276,39 @@ namespace Mapster.Tests
     //        return dest;
     //    }
 
+ #endregion NowNotWorking
+
+
+ }
 
 
 
-    //}
 
 
-
-
-
-    #endregion NowNotWorking
+   
 
 
 
 
 
     #region TestClases
+
+    public class FakeRecord
+    {
+        protected FakeRecord(FakeRecord fake)
+        {
+
+        }
+
+        public FakeRecord()
+        {
+
+        }
+
+        public int X { get; set; }
+    }
+
+
 
 
     class UserAccount

--- a/src/Mapster.Tests/WhenRecordRegration.cs
+++ b/src/Mapster.Tests/WhenRecordRegration.cs
@@ -1,0 +1,415 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Shouldly;
+using System;
+using System.Collections.Generic;
+
+namespace Mapster.Tests
+{
+    /// <summary>
+    /// Tests for https://github.com/MapsterMapper/Mapster/issues/537
+    /// </summary>
+    [TestClass]
+
+    public class WhenRecordRegress
+    {
+
+
+        [TestMethod]
+        public void AdaptRecord()
+        {
+            var _sourse = new TestREcord() { X = 700 };
+
+            var _destination = new TestREcord() { X = 500 };
+
+            var _result = _sourse.Adapt(_destination);
+
+            object.ReferenceEquals(_result, _destination).ShouldBeFalse();
+
+
+            var _sourcePositional = new TestRecordPositional(600);
+
+            var _destinationPositional = new TestRecordPositional(900);
+
+            var _positionalResult = _sourcePositional.Adapt(_destinationPositional);
+
+            object.ReferenceEquals(_destinationPositional, _positionalResult).ShouldBeFalse();
+
+
+
+
+            var _sourceStruct = new TestRecordStruct() { X = 1000 };
+
+            var _destinationStruct = new TestRecordStruct() { X = 800 };
+
+            var _structResult = _sourceStruct.Adapt(_destinationStruct);
+
+            object.ReferenceEquals(_destinationPositional, _positionalResult).ShouldBeFalse();
+
+
+            _result.X.ShouldBe(700);
+
+            _positionalResult.X.ShouldBe(600);
+
+            _structResult.X.ShouldBe(1000);
+        }
+
+
+        [TestMethod]
+        public void AdaptRecordToClass()
+        {
+            var _sourse = new TestRecordPositional(200);
+
+            var _destination = new TestClassProtectedCtr(400);
+
+            var _result = _sourse.Adapt(_destination);
+
+
+            object.ReferenceEquals(_destination, _result).ShouldBeTrue();
+
+            _destination.ShouldBeOfType<TestClassProtectedCtr>();
+
+            _destination.X.ShouldBe(200);
+        }
+
+        [TestMethod]
+        public void AdaptClassToRecord()
+        {
+            var _sourse = new TestClassProtectedCtr(200);
+
+            var _destination = new TestRecordPositional(400);
+
+            var _result = _sourse.Adapt(_destination);
+
+
+            object.ReferenceEquals(_destination, _result).ShouldBeFalse();
+
+            _destination.ShouldBeOfType<TestRecordPositional>();
+
+            _result.X.ShouldBe(200);
+        }
+
+
+
+
+
+        [TestMethod]
+        public void AdaptClassIsNotNewInstanse()
+        {
+            var _sourse = new TestClassPublicCtr(200);
+
+            var _destination = new TestClassProtectedCtr(400);
+
+            var _result = _sourse.Adapt(_destination);
+
+
+            object.ReferenceEquals(_destination, _result).ShouldBeTrue();
+
+            _destination.ShouldBeOfType<TestClassProtectedCtr>();
+
+            _destination.X.ShouldBe(200);
+        }
+
+        /// <summary>
+        /// https://github.com/MapsterMapper/Mapster/issues/615
+        /// </summary>
+        [TestMethod]
+        public void AdaptClassIncludeStruct()
+        {
+            TypeAdapterConfig<SourceWithClass, DestinationWithStruct>
+                .ForType()
+                .Map(x => x.TestStruct, x => x.SourceWithStruct.TestStruct);
+
+            var source = new SourceWithClass
+            {
+                SourceWithStruct = new SourceWithStruct
+                {
+                    TestStruct = new TestStruct("A")
+                }
+            };
+
+            var destination = source.Adapt<DestinationWithStruct>();
+
+            destination.TestStruct.Property.ShouldBe("A");
+        }
+
+        /// <summary>
+        /// https://github.com/MapsterMapper/Mapster/issues/482
+        /// </summary>
+        [TestMethod]
+        public void AdaptClassIsPrivateProperty()
+        {
+            var _sourse = new TestClassPublicCtr(200);
+
+            var _destination = new TestClassProtectedCtrPrivateProperty(400, "Me");
+
+            var _result = _sourse.Adapt(_destination);
+
+
+            object.ReferenceEquals(_destination, _result).ShouldBeTrue();
+
+            _destination.ShouldBeOfType<TestClassProtectedCtrPrivateProperty>();
+
+            _destination.X.ShouldBe(200);
+
+            _destination.Name.ShouldBe("Me");
+        }
+
+
+        /// <summary>
+        /// https://github.com/MapsterMapper/Mapster/issues/427
+        /// </summary>
+        [TestMethod]
+        public void UpdateNullable()
+        {
+            var _sourse = new UserAccount("123", "123@gmail.com", new DateTime(2023, 9, 24));
+
+            var _update = new UpdateUser
+            {
+                Id = "123",
+
+            };
+
+            var configDate = new TypeAdapterConfig();
+            configDate.ForType<UpdateUser, UserAccount>()
+                .Map(dest => dest.Modified, src => new DateTime(2025, 9, 24))
+                .IgnoreNullValues(true);
+
+
+            _update.Adapt(_sourse, configDate);
+
+
+
+            var _sourseEmailUpdate = new UserAccount("123", "123@gmail.com", new DateTime(2023, 9, 24));
+
+            var _updateEmail = new UpdateUser
+            {
+                Email = "245@gmail.com",
+            };
+
+
+            var config = new TypeAdapterConfig();
+            config.ForType<UpdateUser, UserAccount>()
+
+                .IgnoreNullValues(true);
+
+
+            var _resultEmail = _updateEmail.Adapt(_sourseEmailUpdate, config);
+
+
+            _sourse.Id.ShouldBe("123");
+            _sourse.Created.ShouldBe(new DateTime(2023, 9, 24));
+            _sourse.Modified.ShouldBe(new DateTime(2025, 9, 24));
+            _sourse.Email.ShouldBe("123@gmail.com");
+
+
+            _sourseEmailUpdate.Id.ShouldBe("123");
+            _sourseEmailUpdate.Created.ShouldBe(new DateTime(2023, 9, 24));
+            _sourseEmailUpdate.Modified.ShouldBe(null);
+            _sourseEmailUpdate.Email.ShouldBe("245@gmail.com");
+
+
+
+        }
+
+    }
+
+
+
+
+
+
+    #region NowNotWorking
+
+
+
+
+    /// <summary>
+    /// https://github.com/MapsterMapper/Mapster/issues/430
+    /// </summary>
+    //    [TestMethod]
+    //    public void CollectionUpdate()
+    //    {
+    //        List<TestClassPublicCtr> sources = new()
+    //        {
+    //            new(541),
+    //            new(234)
+
+    //        };
+
+
+    //        var destination = new List<TestClassPublicCtr>();
+
+
+    //        var _result = sources.Adapt(destination);
+
+    //        destination.Count.ShouldBe(_result.Count);
+
+    //    }
+
+    //    /// <summary>
+    //    /// https://github.com/MapsterMapper/Mapster/issues/524
+    //    /// </summary>
+    //    [TestMethod]
+    //    public void TSousreIsObjectUpdate()
+    //    {
+    //        var source = new TestClassPublicCtr { X = 123 };
+
+    //        var _result = Somemap(source);
+
+    //        _result.X.ShouldBe(123);
+
+    //    }
+
+    //     TestClassPublicCtr Somemap(object source)
+    //    {
+    //        var dest = new TestClassPublicCtr { X = 321 };
+    //        var dest1 = source.Adapt(dest);
+
+    //        return dest;
+    //    }
+
+
+
+
+    //}
+
+
+
+
+
+    #endregion NowNotWorking
+
+
+
+
+
+    #region TestClases
+
+
+    class UserAccount
+    {
+        public UserAccount(string id, string email, DateTime created)
+        {
+            Id = id;
+            Email = email;
+            Created = created;
+
+        }
+
+        protected UserAccount() { }
+
+        public string Id { get; set; }
+        public string? Email { get; set; }
+        public DateTime Created { get; set; }
+        public DateTime? Modified { get; set; }
+    }
+
+    class UpdateUser
+    {
+        public string? Id { get; set; }
+        public string? Email { get; set; }
+
+        public DateTime? Created { get; set; }
+        public DateTime? Modified { get; set; }
+
+    }
+
+
+
+
+
+
+    class DestinationWithStruct
+    {
+        public TestStruct TestStruct { get; set; }
+    }
+
+    class SourceWithClass
+    {
+        public SourceWithStruct SourceWithStruct { get; set; }
+    }
+
+    class SourceWithStruct
+    {
+        public TestStruct TestStruct { get; set; }
+    }
+
+    struct TestStruct
+    {
+        public string Property { get; }
+
+        public TestStruct(string property) : this()
+        {
+            Property = property;
+        }
+    }
+
+
+    class TestClassPublicCtr
+    {
+        public TestClassPublicCtr()
+        {
+
+        }
+
+        public TestClassPublicCtr(int x)
+        {
+            X = x;
+        }
+
+        public int X { get; set; }
+    }
+
+
+    class TestClassProtectedCtr
+    {
+        protected TestClassProtectedCtr()
+        {
+
+        }
+
+        public TestClassProtectedCtr(int x)
+        {
+            X = x;
+        }
+
+        public int X { get; set; }
+    }
+
+
+    class TestClassProtectedCtrPrivateProperty
+    {
+        protected TestClassProtectedCtrPrivateProperty()
+        {
+
+        }
+
+        public TestClassProtectedCtrPrivateProperty(int x, string name)
+        {
+            X = x;
+            Name = name;
+        }
+
+        public int X { get; private set; }
+
+        public string Name { get; private set; }
+    }
+
+
+    record TestREcord()
+    {
+        
+
+        public int X { set; get; }
+    }
+
+    record TestRecordPositional(int X);
+
+    record struct TestRecordStruct
+    {
+        public int X { set; get; }
+    }
+
+
+    #endregion TestClases
+}

--- a/src/Mapster/Adapters/ClassAdapter.cs
+++ b/src/Mapster/Adapters/ClassAdapter.cs
@@ -54,7 +54,28 @@ namespace Mapster.Adapters
         {
             //new TDestination(src.Prop1, src.Prop2)
 
-            if (arg.GetConstructUsing() != null || arg.Settings.MapToConstructor == null)
+            ///
+            bool IsEnableNonPublicMembersAndNotPublicCtorWithoutParams(CompileArgument arg)
+            {
+                if (arg.Settings.EnableNonPublicMembers == null)
+                    return false;
+                if (arg.Settings.EnableNonPublicMembers == false)
+                    return false;
+                else
+                {
+                    if (arg.DestinationType.GetConstructors().Any(x => x.GetParameters() != null))
+                    {
+                        return true;
+                    }
+                }
+
+
+                return false;
+            }
+
+
+
+            if ((arg.GetConstructUsing() != null || arg.Settings.MapToConstructor == null) && !IsEnableNonPublicMembersAndNotPublicCtorWithoutParams(arg))
                 return base.CreateInstantiationExpression(source, destination, arg);
 
             ClassMapping? classConverter;

--- a/src/Mapster/Adapters/RecordTypeAdapter.cs
+++ b/src/Mapster/Adapters/RecordTypeAdapter.cs
@@ -4,7 +4,7 @@ using Mapster.Utils;
 
 namespace Mapster.Adapters
 {
-    internal class RecordTypeAdapter : BaseClassAdapter
+    internal class RecordTypeAdapter : ClassAdapter
     {
         protected override int Score => -149;
         protected override bool UseTargetValue => false;
@@ -34,12 +34,12 @@ namespace Mapster.Adapters
 
         protected override Expression CreateBlockExpression(Expression source, Expression destination, CompileArgument arg)
         {
-            return Expression.Empty();
+            return base.CreateBlockExpression(source, destination, arg);
         }
 
         protected override Expression CreateInlineExpression(Expression source, CompileArgument arg)
         {
-            return CreateInstantiationExpression(source, arg);
+            return base.CreateInstantiationExpression(source, arg);
         }
     }
 

--- a/src/Mapster/Utils/ReflectionUtils.cs
+++ b/src/Mapster/Utils/ReflectionUtils.cs
@@ -170,27 +170,58 @@ namespace Mapster
 
             var props = type.GetFieldsAndProperties().ToList();
 
+            ///
+            ///
+            ///
+            #region SupportingСurrentBehavior for Config Clone and Fork 
+
+            if (type == typeof(MulticastDelegate))
+                return true;
+
+            if (type == typeof(TypeAdapterSetter))
+                return true;
+
+            //  if (type == typeof(TypeAdapterRule))
+            //    return true;
+
+            if (type == typeof(TypeAdapterSettings))
+                return true;
+
+            if (type.IsValueType && type?.GetConstructors().Length != 0)
+            {
+                var test = type.GetConstructors()[0].GetParameters();
+                var param = type.GetConstructors()[0].GetParameters().ToArray();
+
+                if (param[0]?.ParameterType == typeof(TypeTuple) && param[1]?.ParameterType == typeof(TypeAdapterRule))
+                    return true;
+            }
+
+            if (type == typeof(TypeTuple))
+                return true;
+
+            #endregion SupportingСurrentBehavior for Config Clone and Fork 
+
+
             //interface with readonly props
-            if (type.GetTypeInfo().IsInterface && 
+            if (type.GetTypeInfo().IsInterface &&
                 props.Any(p => p.SetterModifier != AccessModifier.Public))
                 return true;
 
-            //1 constructor
-            var ctors = type.GetConstructors().ToList();
-            if (ctors.Count != 1)
-                return false;
+            //constructor
+            var ctors = type.GetConstructors(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public).ToList();
 
-            //ctor must not empty
-            var ctorParams = ctors[0].GetParameters();
-            if (ctorParams.Length == 0)
-                return false;
+            var isRecordTypeCtor = type.GetConstructors(BindingFlags.Instance | BindingFlags.NonPublic)
+                .Where(x => x.IsFamily == true)
+                .Any(x => x.GetParameters()
+                         .Any(y => y.ParameterType == type));
 
-            //all parameters should match getter
-            return props.All(prop =>
-            {
-                var name = prop.Name.ToPascalCase();
-                return ctorParams.Any(p => p.ParameterType == prop.Type && p.Name?.ToPascalCase() == name);
-            });
+
+            if (ctors.Count >= 2 && isRecordTypeCtor)
+                return true;
+
+
+
+            return false;
         }
 
         public static bool IsConvertible(this Type type)


### PR DESCRIPTION
Partial Fix  Bug from issue #537 

Not Fix:
1) Collection bug - #430 
2) Modification from Object To Type #524

Changes:
1) Adapt (Class or Record) To Class not create new instance  
2) Adapt Record To Record always Create new Instanse (before only RecordStruct and PositionalRecord)  **_possible regression_**

Regress:
**Required configuration** from Class that does not have a public constructor without parameters and contains Properties with private setters. .


Problems: 
1) This Bug was involved in the mechanisms of .Fork() and .Clone() configuration 
2) Class like this will be detect as Record
```
public class FakeRecord
{
    protected FakeRecord(FakeRecord fake)
    {

    }

    public FakeRecord()
    {

    }

}
```
 


