### PR TITLE
Added ValidateAndAdapt Methods for Property Validation

### DIFF
--- a/src/Mapster.Tests/WhenRequiresPropsValidation.cs
+++ b/src/Mapster.Tests/WhenRequiresPropsValidation.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using Mapster.Tests.Classes;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Shouldly;
+
+namespace Mapster.Tests
+{
+    [TestClass]
+    public class WhenRequiresPropsValidation
+    {
+        [TestInitialize]
+        public void Setup()
+        {
+            TypeAdapterConfig.GlobalSettings.Clear();
+        }
+
+        [TestCleanup]
+        public void TestCleanup()
+        {
+            TypeAdapterConfig.GlobalSettings.Default.NameMatchingStrategy(NameMatchingStrategy.Exact);
+        }
+
+        [TestMethod]
+        public void DestinationProps_Exist_In_Source()
+        {
+            var product = new Product {Id = Guid.NewGuid(), Title = "ProductA", CreatedUser = new User {Name = "UserA"}};
+
+            var dto = product.ValidateAndAdapt<Product, ProductNestedDTO>();
+
+            dto.ShouldNotBeNull();
+            dto.Id.ShouldBe(product.Id);
+        }
+        
+        [TestMethod]
+        public void DestinationProps_Not_Exist_In_Source()
+        {
+            var product = new Product {Id = Guid.NewGuid(), Title = "ProductA", CreatedUser = new User {Name = "UserA"}};
+            
+            ProductDTO productDtoRef;
+            var notExistingPropName = nameof(productDtoRef.CreatedUserName);
+
+            var ex = Should.Throw<Exception>(() => product.ValidateAndAdapt<Product, ProductDTO>());
+            
+            ex.Message.ShouldContain(notExistingPropName);
+            ex.Message.ShouldContain(nameof(Product));
+        }
+    }
+}

--- a/src/Mapster.Tests/WhenRequiresPropsValidationWithAdapterConfig.cs
+++ b/src/Mapster.Tests/WhenRequiresPropsValidationWithAdapterConfig.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using Mapster.Tests.Classes;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Shouldly;
+
+namespace Mapster.Tests
+{
+    [TestClass]
+    public class WhenRequiresPropsValidationWithAdapterConfig
+    {
+        [TestInitialize]
+        public void Setup()
+        {
+            TypeAdapterConfig.GlobalSettings.Clear();
+        }
+
+        [TestCleanup]
+        public void TestCleanup()
+        {
+            TypeAdapterConfig.GlobalSettings.Default.NameMatchingStrategy(NameMatchingStrategy.Exact);
+        }
+        
+        [TestMethod]
+        public void DestinationProps_Not_Exist_In_Source_But_Configured()
+        {
+            var product = new Product {Id = Guid.NewGuid(), Title = "ProductA", CreatedUser = new User {Name = "UserA"}};
+
+            var adapterSettings = TypeAdapterConfig<Product, ProductDTO>.NewConfig()
+                .Map(dest => dest.CreatedUserName, src => $"{src.CreatedUser.Name} {src.CreatedUser.Surname}");
+
+            var dto = product.ValidateAndAdapt<Product, ProductDTO>(adapterSettings.Config);
+
+            dto.ShouldNotBeNull();
+            dto.CreatedUserName.ShouldBe($"{product.CreatedUser.Name} {product.CreatedUser.Surname}");
+        }
+        
+        [TestMethod]
+        public void DestinationProps_Not_Exist_In_Source_And_MisConfigured()
+        {
+            var product = new Product {Id = Guid.NewGuid(), Title = "ProductA", CreatedUser = new User {Name = "UserA"}};
+
+            var adapterSettings = TypeAdapterConfig<Product, ProductDTO>.NewConfig();
+
+            ProductDTO productDtoRef;
+            var notExistingPropName = nameof(productDtoRef.CreatedUserName);
+
+            var ex = Should.Throw<Exception>(() => product.ValidateAndAdapt<Product, ProductDTO>(adapterSettings.Config));
+            
+            ex.Message.ShouldContain(notExistingPropName);
+            ex.Message.ShouldContain(nameof(Product));
+        }
+    }
+}

--- a/src/Mapster/TypeAdapter.cs
+++ b/src/Mapster/TypeAdapter.cs
@@ -1,5 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
+using Mapster.Models;
 
 namespace Mapster
 {
@@ -169,6 +172,60 @@ namespace Mapster
                 //DynamicInvoke is slow, but works with non-public
                 return del.DynamicInvoke(source, destination);
             }
+        }
+        
+        /// <summary>
+        /// Validate properties and Adapt the source object to the destination type.
+        /// </summary>
+        /// <typeparam name="TSource">Source type.</typeparam>
+        /// <typeparam name="TDestination">Destination type.</typeparam>
+        /// <param name="source">Source object to adapt.</param>
+        /// <returns>Adapted destination type.</returns>
+        public static TDestination ValidateAndAdapt<TSource, TDestination>(this TSource source)
+        {
+            var entityType = typeof(TSource);
+            var selectorType = typeof(TDestination);
+
+            var entityProperties = new HashSet<string>(entityType.GetProperties().Select(p => p.Name));
+            var selectorProperties = new HashSet<string>(selectorType.GetProperties().Select(p=> p.Name));
+
+            foreach (var selectorProperty in selectorProperties)
+            {
+                if (entityProperties.Contains(selectorProperty)) continue;
+                throw new Exception($"Property {selectorProperty} does not exist in {entityType.Name} and is not configured in Mapster");
+            }
+            return source.Adapt<TDestination>();
+        }
+        
+        /// <summary>
+        /// Validate properties and Adapt the source object to the destination type.
+        /// </summary>
+        /// <typeparam name="TSource">Source type.</typeparam>
+        /// <typeparam name="TDestination">Destination type.</typeparam>
+        /// <param name="source">Source object to adapt.</param>
+        /// <param name="config">Configuration</param>
+        /// <returns>Adapted destination type.</returns>
+        public static TDestination ValidateAndAdapt<TSource, TDestination>(this TSource source, TypeAdapterConfig config)
+        {
+            var entityType = typeof(TSource);
+            var selectorType = typeof(TDestination);
+
+            var entityProperties = new HashSet<string>(entityType.GetProperties().Select(p => p.Name));
+            var selectorProperties = new HashSet<string>(selectorType.GetProperties().Select(p=> p.Name));
+
+            // Get the rule map for the current types
+            var ruleMap = config.RuleMap;
+            var typeTuple = new TypeTuple(entityType, selectorType);
+            ruleMap.TryGetValue(typeTuple, out var rule);
+
+            foreach (var selectorProperty in selectorProperties)
+            {
+                if (entityProperties.Contains(selectorProperty)) continue;
+                // Check whether the adapter config has a config for the property
+                if (rule != null && rule.Settings.Resolvers.Any(r => r.DestinationMemberName.Equals(selectorProperty))) continue;
+                throw new Exception($"Property {selectorProperty} does not exist in {entityType.Name} and is not configured in Mapster");
+            }
+            return source.Adapt<TDestination>(config);
         }
     }
 

--- a/src/Mapster/TypeAdapter.cs
+++ b/src/Mapster/TypeAdapter.cs
@@ -183,22 +183,22 @@ namespace Mapster
         /// <returns>Adapted destination type.</returns>
         public static TDestination ValidateAndAdapt<TSource, TDestination>(this TSource source)
         {
-            var entityType = typeof(TSource);
+            var sourceType = typeof(TSource);
             var selectorType = typeof(TDestination);
 
-            var entityProperties = new HashSet<string>(entityType.GetProperties().Select(p => p.Name));
+            var sourceProperties = new HashSet<string>(sourceType.GetProperties().Select(p => p.Name));
             var selectorProperties = new HashSet<string>(selectorType.GetProperties().Select(p=> p.Name));
 
             foreach (var selectorProperty in selectorProperties)
             {
-                if (entityProperties.Contains(selectorProperty)) continue;
-                throw new Exception($"Property {selectorProperty} does not exist in {entityType.Name} and is not configured in Mapster");
+                if (sourceProperties.Contains(selectorProperty)) continue;
+                throw new Exception($"Property {selectorProperty} does not exist in {sourceType.Name} and is not configured in Mapster");
             }
             return source.Adapt<TDestination>();
         }
         
         /// <summary>
-        /// Validate properties and Adapt the source object to the destination type.
+        /// Validate properties with configuration and Adapt the source object to the destination type.
         /// </summary>
         /// <typeparam name="TSource">Source type.</typeparam>
         /// <typeparam name="TDestination">Destination type.</typeparam>
@@ -207,23 +207,23 @@ namespace Mapster
         /// <returns>Adapted destination type.</returns>
         public static TDestination ValidateAndAdapt<TSource, TDestination>(this TSource source, TypeAdapterConfig config)
         {
-            var entityType = typeof(TSource);
+            var sourceType = typeof(TSource);
             var selectorType = typeof(TDestination);
 
-            var entityProperties = new HashSet<string>(entityType.GetProperties().Select(p => p.Name));
+            var sourceProperties = new HashSet<string>(sourceType.GetProperties().Select(p => p.Name));
             var selectorProperties = new HashSet<string>(selectorType.GetProperties().Select(p=> p.Name));
 
             // Get the rule map for the current types
             var ruleMap = config.RuleMap;
-            var typeTuple = new TypeTuple(entityType, selectorType);
+            var typeTuple = new TypeTuple(sourceType, selectorType);
             ruleMap.TryGetValue(typeTuple, out var rule);
 
             foreach (var selectorProperty in selectorProperties)
             {
-                if (entityProperties.Contains(selectorProperty)) continue;
+                if (sourceProperties.Contains(selectorProperty)) continue;
                 // Check whether the adapter config has a config for the property
                 if (rule != null && rule.Settings.Resolvers.Any(r => r.DestinationMemberName.Equals(selectorProperty))) continue;
-                throw new Exception($"Property {selectorProperty} does not exist in {entityType.Name} and is not configured in Mapster");
+                throw new Exception($"Property {selectorProperty} does not exist in {sourceType.Name} and is not configured in Mapster");
             }
             return source.Adapt<TDestination>(config);
         }


### PR DESCRIPTION
This PR introduces two new extension methods, `ValidateAndAdapt`, for the Mapster library. These methods ensure that all properties in the destination type either exist in the source type or are configured in Mapster. If a property does not exist and is not configured, an exception is thrown.

The PR includes:
- Implementation of `ValidateAndAdapt` methods.
- Test cases that cover different scenarios.

### Usage

```C#
public static class ReportSelectors
{


    #region Selectors

    /// <summary>
    ///     Select WitnessId
    /// </summary>
    /// <returns>new <see cref="PermissionsToEditProps" />{ WitnessId = report.WitnessId }</returns>
    public static readonly Expression<Func<Report, PermissionsToEditProps>> PermissionsToEdit =
        e => e.ValidateAndAdapt<Report, PermissionsToEditProps>();

    /// <summary>
    ///     Select ModeratorId, Status
    /// </summary>
    /// <returns>new <see cref="PermissionsToModerateProps" />{ ModeratorId = report.ModeratorId, Status = report.Status }</returns>
    public static readonly Expression<Func<Report, PermissionsToModerateProps>> PermissionsToModerate =
        e => e.ValidateAndAdapt<Report, PermissionsToModerateProps>();

    /// <summary>
    ///     Select WitnessId, Status
    /// </summary>
    /// <returns>new <see cref="PermissionsToViewProps" />{ WitnessId = report.WitnessId, Status = report.Status }</returns>
    public static readonly Expression<Func<Report, PermissionsToViewProps>> PermissionsToView =
        e => e.ValidateAndAdapt<Report, PermissionsToViewProps>(PermissionsToViewPropsAdapter.Config);

    #endregion


    #region Selector Properties

    public record PermissionsToEditProps(WitnessId WitnessId);

    public record PermissionsToModerateProps(ModeratorId? ModeratorId, Status Status);

    public record PermissionsToViewProps(WitnessId WitnessId, WitnessDto Witness, Status Status)
    {
        /// <summary>
        ///     Adapter Settings for <see cref="Witness" />
        /// </summary>
        internal static readonly TypeAdapterSetter<Witness, WitnessDto> WitnessDtoAdapter =
            TypeAdapterConfig<Witness, WitnessDto>.NewConfig()
                .Map(s => s.WitnessId, e => e.Id);
    }

    #endregion


    #region Adapter Settings

    /// <summary>
    ///     Adapter Settings for <see cref="PermissionsToViewProps" />
    /// </summary>
    private static readonly TypeAdapterSetter<Report, PermissionsToViewProps> PermissionsToViewPropsAdapter =
        TypeAdapterConfig<Report, PermissionsToViewProps>.NewConfig()
            .Map(s => s.WitnessId, e => e.WitnessId)
            .Map(s => s.Witness,
                e => e.Witness!.ValidateAndAdapt<Witness, WitnessDto>(PermissionsToViewProps.WitnessDtoAdapter.Config));

    #endregion


}
```