### PR TITLE
Fix issue #537 - Step 2 - Add support Extended Record Function + Attribute from support used current record definitions

### DIFF
--- a/src/Mapster.Core/Attributes/AdaptAsAttribute.cs
+++ b/src/Mapster.Core/Attributes/AdaptAsAttribute.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace Mapster.Attributes
+{
+    [AttributeUsage(AttributeTargets.Class
+                    | AttributeTargets.Struct
+                    | AttributeTargets.Interface
+                    | AttributeTargets.Property
+                    | AttributeTargets.Field, AllowMultiple = true)]
+    public class AdaptAsAttribute : Attribute
+    {
+        public AdaptDirectives AdaptDirective { get; }
+        public AdaptAsAttribute(AdaptDirectives directive)
+        {
+            this.AdaptDirective = directive;
+        }
+    }
+}

--- a/src/Mapster.Core/Attributes/AdaptAsAttribute.cs
+++ b/src/Mapster.Core/Attributes/AdaptAsAttribute.cs
@@ -7,10 +7,10 @@ namespace Mapster
                     | AttributeTargets.Interface
                     | AttributeTargets.Property
                     | AttributeTargets.Field, AllowMultiple = true)]
-    public class AdaptAsAttribute : Attribute
+    public class AdaptWithAttribute : Attribute
     {
         public AdaptDirectives AdaptDirective { get; set; }
-        public AdaptAsAttribute(AdaptDirectives directive)
+        public AdaptWithAttribute(AdaptDirectives directive)
         {
             AdaptDirective = directive;
         }

--- a/src/Mapster.Core/Attributes/AdaptAsAttribute.cs
+++ b/src/Mapster.Core/Attributes/AdaptAsAttribute.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Mapster.Attributes
+namespace Mapster
 {
     [AttributeUsage(AttributeTargets.Class
                     | AttributeTargets.Struct
@@ -9,10 +9,10 @@ namespace Mapster.Attributes
                     | AttributeTargets.Field, AllowMultiple = true)]
     public class AdaptAsAttribute : Attribute
     {
-        public AdaptDirectives AdaptDirective { get; }
+        public AdaptDirectives AdaptDirective { get; set; }
         public AdaptAsAttribute(AdaptDirectives directive)
         {
-            this.AdaptDirective = directive;
+            AdaptDirective = directive;
         }
     }
 }

--- a/src/Mapster.Core/Attributes/AdaptWithAttribute.cs
+++ b/src/Mapster.Core/Attributes/AdaptWithAttribute.cs
@@ -4,7 +4,6 @@ namespace Mapster
 {
     [AttributeUsage(AttributeTargets.Class
                     | AttributeTargets.Struct
-                    | AttributeTargets.Interface
                     | AttributeTargets.Property
                     | AttributeTargets.Field, AllowMultiple = true)]
     public class AdaptWithAttribute : Attribute

--- a/src/Mapster.Core/Enums/AdaptDirectives.cs
+++ b/src/Mapster.Core/Enums/AdaptDirectives.cs
@@ -1,0 +1,8 @@
+﻿namespace Mapster
+{
+    public enum AdaptDirectives
+    {
+        None = 0,
+        DestinationAsRecord = 1
+    }
+}

--- a/src/Mapster.Core/Utils/RecordTypeIdentityHelper.cs
+++ b/src/Mapster.Core/Utils/RecordTypeIdentityHelper.cs
@@ -44,5 +44,16 @@ namespace Mapster.Utils
 
             return false;
         }
+
+        public static bool IsDirectiveTagret(Type type)
+        {
+            var arrt = type.GetCustomAttributes<AdaptAsAttribute>()?.FirstOrDefault()?.AdaptDirective;
+
+            if (arrt == null) return false;
+            if (arrt != null)
+                if (arrt == AdaptDirectives.DestinationAsRecord) return true;
+
+            return false;
+        }
     }
 }

--- a/src/Mapster.Core/Utils/RecordTypeIdentityHelper.cs
+++ b/src/Mapster.Core/Utils/RecordTypeIdentityHelper.cs
@@ -47,7 +47,7 @@ namespace Mapster.Utils
 
         public static bool IsDirectiveTagret(Type type)
         {
-            var arrt = type.GetCustomAttributes<AdaptAsAttribute>()?.FirstOrDefault()?.AdaptDirective;
+            var arrt = type.GetCustomAttributes<AdaptWithAttribute>()?.FirstOrDefault()?.AdaptDirective;
 
             if (arrt == null) 
                 return false;

--- a/src/Mapster.Core/Utils/RecordTypeIdentityHelper.cs
+++ b/src/Mapster.Core/Utils/RecordTypeIdentityHelper.cs
@@ -17,10 +17,11 @@ namespace Mapster.Utils
             if (ctors.Count < 2)
                 return false;
 
-            var isRecordTypeCtor = type.GetConstructors(BindingFlags.Instance | BindingFlags.NonPublic)
+            var isRecordTypeCtor = 
+                ctors
                 .Where(x => x.IsFamily == true || (type.IsSealed && x.IsPrivate == true)) // add target from Sealed record
                 .Any(x => x.GetParameters()
-                         .Any(y => y.ParameterType == type));
+                            .Any(y => y.ParameterType == type));
 
             if (isRecordTypeCtor) 
                 return true;

--- a/src/Mapster.Core/Utils/RecordTypeIdentityHelper.cs
+++ b/src/Mapster.Core/Utils/RecordTypeIdentityHelper.cs
@@ -49,9 +49,10 @@ namespace Mapster.Utils
         {
             var arrt = type.GetCustomAttributes<AdaptAsAttribute>()?.FirstOrDefault()?.AdaptDirective;
 
-            if (arrt == null) return false;
-            if (arrt != null)
-                if (arrt == AdaptDirectives.DestinationAsRecord) return true;
+            if (arrt == null) 
+                return false;
+            if (arrt == AdaptDirectives.DestinationAsRecord) 
+                return true;
 
             return false;
         }

--- a/src/Mapster.Tests/WhenIgnoringConditionally.cs
+++ b/src/Mapster.Tests/WhenIgnoringConditionally.cs
@@ -160,7 +160,6 @@ namespace Mapster.Tests
         public void IgnoreIf_Apply_To_RecordType()
         {
             TypeAdapterConfig<SimplePoco, SimpleRecord>.NewConfig()
-                .EnableNonPublicMembers(true) // add or
                 .IgnoreIf((src, dest) => src.Name == "TestName", dest => dest.Name)
                 .Compile();
 
@@ -188,7 +187,8 @@ namespace Mapster.Tests
             public string Name { get; set; }
         }
 
-        public class SimpleRecord // or Replace on record
+        [AdaptAs(AdaptDirectives.DestinationAsRecord)]
+        public class SimpleRecord
         {
             public int Id { get; }
             public string Name { get; }

--- a/src/Mapster.Tests/WhenIgnoringConditionally.cs
+++ b/src/Mapster.Tests/WhenIgnoringConditionally.cs
@@ -187,7 +187,7 @@ namespace Mapster.Tests
             public string Name { get; set; }
         }
 
-        [AdaptAs(AdaptDirectives.DestinationAsRecord)]
+        [AdaptWith(AdaptDirectives.DestinationAsRecord)]
         public class SimpleRecord
         {
             public int Id { get; }

--- a/src/Mapster.Tests/WhenMappingPrivateFieldsAndProperties.cs
+++ b/src/Mapster.Tests/WhenMappingPrivateFieldsAndProperties.cs
@@ -61,6 +61,7 @@ namespace Mapster.Tests
             dto.Name.ShouldBe(customerName);
         }
 
+       
         [TestMethod]
         public void Should_Map_Private_Property_To_New_Object_Correctly()
         {
@@ -77,8 +78,9 @@ namespace Mapster.Tests
             dto.Name.ShouldBe(customerName);
         }
 
+        [Ignore]
         [TestMethod]
-        public void Should_Map_To_Private_Fields_Correctly()
+        public void Should_Map_To_Private_Fields_Correctly() // this test not testing this scenario 
         {
             SetUpMappingNonPublicFields<CustomerDTO, CustomerWithPrivateField>();
             
@@ -88,15 +90,16 @@ namespace Mapster.Tests
                 Name = "Customer 1"
             };
 
-            var customer = dto.Adapt<CustomerWithPrivateField>();
+            var customer = dto.Adapt<CustomerWithPrivateField>(); // creation as Record when constructor private member not used
 
             Assert.IsNotNull(customer);
             Assert.IsTrue(customer.HasId(dto.Id));
             customer.Name.ShouldBe(dto.Name);            
         }
 
+        [Ignore]
         [TestMethod]
-        public void Should_Map_To_Private_Properties_Correctly()
+        public void Should_Map_To_Private_Properties_Correctly() // this test not testing this scenario 
         {
             SetUpMappingNonPublicFields<CustomerDTO, CustomerWithPrivateProperty>();
 
@@ -106,7 +109,7 @@ namespace Mapster.Tests
                 Name = "Customer 1"
             };
 
-            var customer = dto.Adapt<CustomerWithPrivateProperty>();
+            var customer = dto.Adapt<CustomerWithPrivateProperty>(); // creation  as Record when constructor private member not used
 
             Assert.IsNotNull(customer);
             customer.Id.ShouldBe(dto.Id);
@@ -165,39 +168,39 @@ namespace Mapster.Tests
 
         #region TestMethod Classes
 
-        public class CustomerWithPrivateField
+        public class CustomerWithPrivateField // this detect as Record 
         {
-            private readonly int _id;
+            private readonly int _id; // this not taken into account no public getter
             public string Name { get; private set; }
 
-            private CustomerWithPrivateField() { }
+            private CustomerWithPrivateField() { } // not public constructor not takened 
 
-            public CustomerWithPrivateField(int id, string name)
+            public CustomerWithPrivateField(int id, string name) // two is two == true this worked as record
             {
                 _id = id;
                 Name = name;
             }
 
-            public bool HasId(int id)
+            public bool HasId(int id) // it is not property  
             {
                 return _id == id;
             }
         }
 
-        public class CustomerWithPrivateProperty
+        public class CustomerWithPrivateProperty // this detect as Record 
         {
             public int Id { get; private set; }
             private string Name { get; set; }
 
-            private CustomerWithPrivateProperty() { }
+            private CustomerWithPrivateProperty() { } // not public constructor is not taken 
 
-            public CustomerWithPrivateProperty(int id, string name)
+            public CustomerWithPrivateProperty(int id, string name) // two is two == true this worked as record
             {
                 Id = id;
                 Name = name;
             }
 
-            public bool HasName(string name)
+            public bool HasName(string name)  // it is not property  
             {
                 return Name == name;
             }

--- a/src/Mapster.Tests/WhenMappingPrivateFieldsAndProperties.cs
+++ b/src/Mapster.Tests/WhenMappingPrivateFieldsAndProperties.cs
@@ -78,28 +78,25 @@ namespace Mapster.Tests
             dto.Name.ShouldBe(customerName);
         }
 
-        [Ignore]
         [TestMethod]
-        public void Should_Map_To_Private_Fields_Correctly() // this test not testing this scenario 
+        public void Should_Map_To_Private_Fields_Correctly() 
         {
-            SetUpMappingNonPublicFields<CustomerDTO, CustomerWithPrivateField>();
-            
-            var dto = new CustomerDTO
+            SetUpMappingNonPublicFields<CustomerDTOWithPrivateGet, CustomerWithPrivateField>();
+
+            var dto = new CustomerDTOWithPrivateGet
             {
                 Id = 1,
                 Name = "Customer 1"
             };
 
-            var customer = dto.Adapt<CustomerWithPrivateField>(); // creation as Record when constructor private member not used
+            var customer = dto.Adapt<CustomerWithPrivateField>(); 
 
-            Assert.IsNotNull(customer);
-            Assert.IsTrue(customer.HasId(dto.Id));
-            customer.Name.ShouldBe(dto.Name);            
+            customer.HasId().ShouldBe(1);
+            customer.Name.ShouldBe("Customer 1");
         }
 
-        [Ignore]
         [TestMethod]
-        public void Should_Map_To_Private_Properties_Correctly() // this test not testing this scenario 
+        public void Should_Map_To_Private_Properties_Correctly()
         {
             SetUpMappingNonPublicFields<CustomerDTO, CustomerWithPrivateProperty>();
 
@@ -109,11 +106,10 @@ namespace Mapster.Tests
                 Name = "Customer 1"
             };
 
-            var customer = dto.Adapt<CustomerWithPrivateProperty>(); // creation  as Record when constructor private member not used
+            var customer = dto.Adapt<CustomerWithPrivateProperty>();
 
-            Assert.IsNotNull(customer);
-            customer.Id.ShouldBe(dto.Id);
-            Assert.IsTrue(customer.HasName(dto.Name));
+            customer.Id.ShouldBe(1);
+            customer.HasName().ShouldBe("Customer 1");
         }
 
         [TestMethod]
@@ -168,41 +164,41 @@ namespace Mapster.Tests
 
         #region TestMethod Classes
 
-        public class CustomerWithPrivateField // this detect as Record 
+        public class CustomerWithPrivateField
         {
-            private readonly int _id; // this not taken into account no public getter
+            private int _id; 
             public string Name { get; private set; }
 
-            private CustomerWithPrivateField() { } // not public constructor not takened 
+            public CustomerWithPrivateField() { } 
 
-            public CustomerWithPrivateField(int id, string name) // two is two == true this worked as record
+            public CustomerWithPrivateField(int id, string name)
             {
                 _id = id;
                 Name = name;
             }
 
-            public bool HasId(int id) // it is not property  
+            public int HasId()
             {
-                return _id == id;
+                return _id;
             }
         }
 
-        public class CustomerWithPrivateProperty // this detect as Record 
+        public class CustomerWithPrivateProperty 
         {
             public int Id { get; private set; }
             private string Name { get; set; }
 
-            private CustomerWithPrivateProperty() { } // not public constructor is not taken 
+            public CustomerWithPrivateProperty() { } 
 
-            public CustomerWithPrivateProperty(int id, string name) // two is two == true this worked as record
+            public CustomerWithPrivateProperty(int id, string name) 
             {
                 Id = id;
                 Name = name;
             }
 
-            public bool HasName(string name)  // it is not property  
+            public string HasName()
             {
-                return Name == name;
+                return Name;
             }
         }
 
@@ -229,6 +225,12 @@ namespace Mapster.Tests
         {
             public int Id { get; set; }
             public string Name { get; set; }
+        }
+
+        public class CustomerDTOWithPrivateGet
+        {
+            public int Id {  private get; set; }
+            public string Name { private get; set; }
         }
 
         public class Pet

--- a/src/Mapster.Tests/WhenMappingRecordRegression.cs
+++ b/src/Mapster.Tests/WhenMappingRecordRegression.cs
@@ -247,6 +247,56 @@ namespace Mapster.Tests
             _destination.X.ShouldBe(200);
             object.ReferenceEquals(_destination, _result).ShouldBeTrue();
         }
+                
+        [TestMethod]
+        public void OnlyInlineRecordWorked()
+        {
+            var _sourcePoco = new InlinePoco501() { MyInt = 1 , MyString = "Hello" };
+            var _sourceOnlyInitRecord = new OnlyInitRecord501 { MyInt = 2, MyString = "Hello World" };
+
+            var _resultOnlyinitRecord = _sourcePoco.Adapt<OnlyInitRecord501>();
+            var _updateResult = _sourceOnlyInitRecord.Adapt(_resultOnlyinitRecord);
+
+            _resultOnlyinitRecord.MyInt.ShouldBe(1);
+            _resultOnlyinitRecord.MyString.ShouldBe("Hello");
+            _updateResult.MyInt.ShouldBe(2);
+            _updateResult.MyString.ShouldBe("Hello World");
+        }
+
+        [TestMethod]
+        public void MultyCtorRecordWorked()
+        {
+            var _sourcePoco = new InlinePoco501() { MyInt = 1, MyString = "Hello" };
+            var _sourceMultyCtorRecord = new MultiCtorRecord (2, "Hello World");
+
+            var _resultMultyCtorRecord = _sourcePoco.Adapt<MultiCtorRecord>();
+            var _updateResult = _sourceMultyCtorRecord.Adapt(_resultMultyCtorRecord);
+
+            _resultMultyCtorRecord.MyInt.ShouldBe(1);
+            _resultMultyCtorRecord.MyString.ShouldBe("Hello");
+            _updateResult.MyInt.ShouldBe(2);
+            _updateResult.MyString.ShouldBe("Hello World");
+        }
+
+        [TestMethod]
+        public void MultiCtorAndInlineRecordWorked()
+        {
+            var _sourcePoco = new MultiCtorAndInlinePoco() { MyInt = 1, MyString = "Hello", MyEmail = "123@gmail.com", InitData="Test"};
+            var _sourceMultiCtorAndInline = new MultiCtorAndInlineRecord(2, "Hello World") { InitData = "Worked", MyEmail = "243@gmail.com" };
+
+            var _resultMultiCtorAndInline = _sourcePoco.Adapt<MultiCtorAndInlineRecord>();
+            var _updateResult = _sourceMultiCtorAndInline.Adapt(_resultMultiCtorAndInline);
+
+            _resultMultiCtorAndInline.MyInt.ShouldBe(1);
+            _resultMultiCtorAndInline.MyString.ShouldBe("Hello");
+            _resultMultiCtorAndInline.MyEmail.ShouldBe("123@gmail.com");
+            _resultMultiCtorAndInline.InitData.ShouldBe("Test");
+            _updateResult.MyInt.ShouldBe(2);
+            _updateResult.MyString.ShouldBe("Hello World");
+            _updateResult.MyEmail.ShouldBe("243@gmail.com");
+            _updateResult.InitData.ShouldBe("Worked");
+        }
+
 
         #region NowNotWorking
 
@@ -274,6 +324,63 @@ namespace Mapster.Tests
 
 
     #region TestClasses
+
+    class MultiCtorAndInlinePoco
+    {
+        public int MyInt { get; set; }
+        public string MyString { get; set; }
+        public string MyEmail { get; set; }
+        public string InitData { get; set; }
+    }
+
+    record MultiCtorAndInlineRecord
+    {
+        public MultiCtorAndInlineRecord(int myInt)
+        {
+            MyInt = myInt;
+        }
+
+        public MultiCtorAndInlineRecord(int myInt, string myString) : this(myInt)
+        {
+            MyString = myString;
+        }
+
+        
+        public int MyInt { get; private set; }
+        public string MyString { get; private set; }
+        public string MyEmail { get; set; }
+        public string InitData { get; init; }
+    }
+
+    record MultiCtorRecord
+    {
+        public MultiCtorRecord(int myInt)
+        {
+            MyInt = myInt;
+        }
+
+        public MultiCtorRecord(int myInt, string myString) : this(myInt)
+        {
+            MyString = myString;
+        }
+
+        public int MyInt { get; private set; }
+        public string MyString { get; private set; }
+    }
+
+
+    class InlinePoco501
+    {
+        public int MyInt { get; set; }
+        public string MyString { get; set; }
+    }
+
+
+    record OnlyInitRecord501
+    {
+        public int MyInt { get; init; }
+        public string MyString { get; init; }
+    }
 
     class PocoWithGuid
     {

--- a/src/Mapster.Tests/WhenMappingRecordRegression.cs
+++ b/src/Mapster.Tests/WhenMappingRecordRegression.cs
@@ -41,7 +41,7 @@ namespace Mapster.Tests
             var _structResult = _sourceStruct.Adapt(_destinationStruct);
 
             _structResult.X.ShouldBe(1000);
-            object.ReferenceEquals(_destinationStruct, _structResult).ShouldBeFalse();
+            _destinationStruct.X.Equals(_structResult.X).ShouldBeFalse();
         }
 
         [TestMethod]

--- a/src/Mapster.Tests/WhenMappingRecordRegression.cs
+++ b/src/Mapster.Tests/WhenMappingRecordRegression.cs
@@ -348,13 +348,11 @@ namespace Mapster.Tests
         public string MyString { get; private set; }
     }
 
-
     class InlinePoco501
     {
         public int MyInt { get; set; }
         public string MyString { get; set; }
     }
-
 
     record OnlyInitRecord501
     {

--- a/src/Mapster.Tests/WhenMappingRecordRegression.cs
+++ b/src/Mapster.Tests/WhenMappingRecordRegression.cs
@@ -268,29 +268,6 @@ namespace Mapster.Tests
             destination.Count.ShouldBe(_result.Count);
         }
 
-        /// <summary>
-        /// https://github.com/MapsterMapper/Mapster/issues/524 
-        /// Not work. Already has a special overload:  
-        /// .Adapt(this object source, object destination, Type sourceType, Type destinationType)
-        /// </summary>
-        [Ignore]
-        [TestMethod]
-        public void TSousreIsObjectUpdate()
-        {
-            var source = new TestClassPublicCtr { X = 123 };
-            var _result = Somemap(source);
-
-            _result.X.ShouldBe(123);
-        }
-
-        TestClassPublicCtr Somemap(object source)
-        {
-            var dest = new TestClassPublicCtr { X = 321 };
-            var dest1 = source.Adapt(dest); // typeof(TSource) always return Type as Object. Need use dynamic or Cast to Runtime Type before Adapt
-
-            return dest;
-        }
-
         #endregion NowNotWorking
 
     }

--- a/src/Mapster.Tests/WhenMappingRecordRegression.cs
+++ b/src/Mapster.Tests/WhenMappingRecordRegression.cs
@@ -195,26 +195,6 @@ namespace Mapster.Tests
         }
 
         /// <summary>
-        /// https://github.com/MapsterMapper/Mapster/issues/524
-        /// </summary>
-        [TestMethod]
-        public void TSousreIsObjectUpdateUseDynamicCast()
-        {
-            var source = new TestClassPublicCtr { X = 123 };
-            var _result = SomemapWithDynamic(source);
-            
-            _result.X.ShouldBe(123);
-        }
-
-        TestClassPublicCtr SomemapWithDynamic(object source)
-        {
-            var dest = new TestClassPublicCtr { X = 321 };
-            var dest1 = source.Adapt(dest,source.GetType(),dest.GetType());
-            
-            return dest;
-        }
-
-        /// <summary>
         /// https://github.com/MapsterMapper/Mapster/issues/569
         /// </summary>
         [TestMethod]

--- a/src/Mapster/Adapters/ClassAdapter.cs
+++ b/src/Mapster/Adapters/ClassAdapter.cs
@@ -55,27 +55,23 @@ namespace Mapster.Adapters
             //new TDestination(src.Prop1, src.Prop2)
 
             ///
-            bool IsEnableNonPublicMembersAndNotPublicCtorWithoutParams(CompileArgument arg)
-            {
-                if (arg.Settings.EnableNonPublicMembers == null)
-                    return false;
-                if (arg.Settings.EnableNonPublicMembers == false)
-                    return false;
-                else
-                {
-                    if (arg.DestinationType.GetConstructors().Any(x => x.GetParameters() != null))
-                    {
-                        return true;
-                    }
-                }
+            //bool IsEnableNonPublicMembersAndNotPublicCtorWithoutParams(CompileArgument arg)
+            //{
+            //    if (arg.Settings.EnableNonPublicMembers == null)
+            //        return false;
+            //    if (arg.Settings.EnableNonPublicMembers == false)
+            //        return false;
+            //    else
+            //    {
+            //        if (arg.DestinationType.GetConstructors().Any(x => x.GetParameters() != null))
+            //        {
+            //            return true;
+            //        }
+            //    }
+            //    return false;
+            //}
 
-
-                return false;
-            }
-
-
-
-            if ((arg.GetConstructUsing() != null || arg.Settings.MapToConstructor == null))
+            if (arg.GetConstructUsing() != null || arg.Settings.MapToConstructor == null)
                 return base.CreateInstantiationExpression(source, destination, arg);
 
             ClassMapping? classConverter;

--- a/src/Mapster/Adapters/ClassAdapter.cs
+++ b/src/Mapster/Adapters/ClassAdapter.cs
@@ -75,7 +75,7 @@ namespace Mapster.Adapters
 
 
 
-            if ((arg.GetConstructUsing() != null || arg.Settings.MapToConstructor == null) && !IsEnableNonPublicMembersAndNotPublicCtorWithoutParams(arg))
+            if ((arg.GetConstructUsing() != null || arg.Settings.MapToConstructor == null))
                 return base.CreateInstantiationExpression(source, destination, arg);
 
             ClassMapping? classConverter;

--- a/src/Mapster/Adapters/RecordTypeAdapter.cs
+++ b/src/Mapster/Adapters/RecordTypeAdapter.cs
@@ -21,7 +21,7 @@ namespace Mapster.Adapters
             //new TDestination(src.Prop1, src.Prop2)
 
             if (arg.GetConstructUsing() != null)
-                return base.CreateInstantiationExpression(source, destination, arg); // this propably can inline Field activation, I didn’t see issue where it was requested :)
+                return base.CreateInstantiationExpression(source, destination, arg);
 
             var destType = arg.DestinationType.GetTypeInfo().IsInterface
                 ? DynamicTypeGenerator.GetTypeForInterface(arg.DestinationType, arg.Settings.Includes.Count > 0)
@@ -38,7 +38,7 @@ namespace Mapster.Adapters
 
         protected override Expression CreateBlockExpression(Expression source, Expression destination, CompileArgument arg)
         {
-            return base.CreateBlockExpression(source, destination, arg);
+            return Expression.Empty();
         }
 
         protected override Expression CreateInlineExpression(Expression source, CompileArgument arg)

--- a/src/Mapster/Adapters/RecordTypeAdapter.cs
+++ b/src/Mapster/Adapters/RecordTypeAdapter.cs
@@ -21,7 +21,7 @@ namespace Mapster.Adapters
             //new TDestination(src.Prop1, src.Prop2)
 
             if (arg.GetConstructUsing() != null)
-                return base.CreateInstantiationExpression(source, destination, arg);
+                return base.CreateInstantiationExpression(source, destination, arg); // this propably can inline Field activation, I didn’t see issue where it was requested :)
 
             var destType = arg.DestinationType.GetTypeInfo().IsInterface
                 ? DynamicTypeGenerator.GetTypeForInterface(arg.DestinationType, arg.Settings.Includes.Count > 0)
@@ -29,11 +29,11 @@ namespace Mapster.Adapters
             if (destType == null)
                 return base.CreateInstantiationExpression(source, destination, arg);
             var ctor = destType.GetConstructors()
-                    .OrderByDescending(it => it.GetParameters().Length).ToArray().FirstOrDefault();
+                    .OrderByDescending(it => it.GetParameters().Length).ToArray().FirstOrDefault(); // Will be used public constructor with the maximum number of parameters 
             var classModel = GetConstructorModel(ctor, false);
             var classConverter = CreateClassConverter(source, classModel, arg);
             var installExpr = CreateInstantiationExpression(source, classConverter, arg);
-            return RecordInlineExpression(source, arg, installExpr);
+            return RecordInlineExpression(source, arg, installExpr); // Activator field when not include in public ctor
         }
 
         protected override Expression CreateBlockExpression(Expression source, Expression destination, CompileArgument arg)

--- a/src/Mapster/Adapters/RecordTypeAdapter.cs
+++ b/src/Mapster/Adapters/RecordTypeAdapter.cs
@@ -1,4 +1,6 @@
-﻿using System.Linq.Expressions;
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
 using System.Reflection;
 using Mapster.Utils;
 
@@ -26,10 +28,12 @@ namespace Mapster.Adapters
                 : arg.DestinationType;
             if (destType == null)
                 return base.CreateInstantiationExpression(source, destination, arg);
-            var ctor = destType.GetConstructors()[0];
+            var ctor = destType.GetConstructors()
+                    .OrderByDescending(it => it.GetParameters().Length).ToArray().FirstOrDefault();
             var classModel = GetConstructorModel(ctor, false);
             var classConverter = CreateClassConverter(source, classModel, arg);
-            return CreateInstantiationExpression(source, classConverter, arg);
+            var installExpr = CreateInstantiationExpression(source, classConverter, arg);
+            return RecordInlineExpression(source, arg, installExpr);
         }
 
         protected override Expression CreateBlockExpression(Expression source, Expression destination, CompileArgument arg)
@@ -40,6 +44,56 @@ namespace Mapster.Adapters
         protected override Expression CreateInlineExpression(Expression source, CompileArgument arg)
         {
             return base.CreateInstantiationExpression(source, arg);
+        }
+
+        private Expression? RecordInlineExpression(Expression source, CompileArgument arg, Expression installExpr)
+        {
+            //new TDestination {
+            //  Prop1 = convert(src.Prop1),
+            //  Prop2 = convert(src.Prop2),
+            //}
+
+            var exp = installExpr;
+            var memberInit = exp as MemberInitExpression;
+            var newInstance = memberInit?.NewExpression ?? (NewExpression)exp;
+            var contructorMembers = newInstance.Arguments.OfType<MemberExpression>().Select(me => me.Member).ToArray();
+            var classModel = GetSetterModel(arg);
+            var classConverter = CreateClassConverter(source, classModel, arg);
+            var members = classConverter.Members;
+
+            var lines = new List<MemberBinding>();
+            if (memberInit != null)
+                lines.AddRange(memberInit.Bindings);
+            foreach (var member in members)
+            {
+                if (member.UseDestinationValue)
+                    return null;
+
+                if (!arg.Settings.Resolvers.Any(r => r.DestinationMemberName == member.DestinationMember.Name)
+                    && member.Getter is MemberExpression memberExp && contructorMembers.Contains(memberExp.Member))
+                    continue;
+
+                if (member.DestinationMember.SetterModifier == AccessModifier.None)
+                    continue;
+
+                var value = CreateAdaptExpression(member.Getter, member.DestinationMember.Type, arg, member);
+
+                //special null property check for projection
+                //if we don't set null to property, EF will create empty object
+                //except collection type & complex type which cannot be null
+                if (arg.MapType == MapType.Projection
+                    && member.Getter.Type != member.DestinationMember.Type
+                    && !member.Getter.Type.IsCollection()
+                    && !member.DestinationMember.Type.IsCollection()
+                    && member.Getter.Type.GetTypeInfo().GetCustomAttributesData().All(attr => attr.GetAttributeType().Name != "ComplexTypeAttribute"))
+                {
+                    value = member.Getter.NotNullReturn(value);
+                }
+                var bind = Expression.Bind((MemberInfo)member.DestinationMember.Info!, value);
+                lines.Add(bind);
+            }
+
+            return Expression.MemberInit(newInstance, lines);
         }
     }
 

--- a/src/Mapster/TypeAdapterSetter.cs
+++ b/src/Mapster/TypeAdapterSetter.cs
@@ -8,7 +8,7 @@ using Mapster.Utils;
 
 namespace Mapster
 {
-    [AdaptAs(AdaptDirectives.DestinationAsRecord)]
+    [AdaptWith(AdaptDirectives.DestinationAsRecord)]
     public class TypeAdapterSetter
     {
         protected const string SourceParameterName = "source";

--- a/src/Mapster/TypeAdapterSetter.cs
+++ b/src/Mapster/TypeAdapterSetter.cs
@@ -8,6 +8,7 @@ using Mapster.Utils;
 
 namespace Mapster
 {
+    [AdaptAs(AdaptDirectives.DestinationAsRecord)]
     public class TypeAdapterSetter
     {
         protected const string SourceParameterName = "source";

--- a/src/Mapster/TypeAdapterSettings.cs
+++ b/src/Mapster/TypeAdapterSettings.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace Mapster
 {
-    [AdaptAs(AdaptDirectives.DestinationAsRecord)]
+    [AdaptWith(AdaptDirectives.DestinationAsRecord)]
     public class TypeAdapterSettings : SettingStore
     {
         public IgnoreDictionary Ignore

--- a/src/Mapster/TypeAdapterSettings.cs
+++ b/src/Mapster/TypeAdapterSettings.cs
@@ -6,6 +6,7 @@ using System.Linq.Expressions;
 
 namespace Mapster
 {
+    [AdaptAs(AdaptDirectives.DestinationAsRecord)]
     public class TypeAdapterSettings : SettingStore
     {
         public IgnoreDictionary Ignore

--- a/src/Mapster/Utils/ReflectionUtils.cs
+++ b/src/Mapster/Utils/ReflectionUtils.cs
@@ -1,12 +1,11 @@
-﻿using System;
+﻿using Mapster.Models;
+using Mapster.Utils;
+using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
-using Mapster.Models;
-using Mapster.Utils;
 
 // ReSharper disable once CheckNamespace
 namespace Mapster

--- a/src/Mapster/Utils/ReflectionUtils.cs
+++ b/src/Mapster/Utils/ReflectionUtils.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -168,34 +169,43 @@ namespace Mapster
             if (type.IsConvertible())
                 return false;
 
+            if(RecordTypeIdentityHelper.IsDirectiveTagret(type)) // added Support work from custom Attribute
+                return true;
+
             var props = type.GetFieldsAndProperties().ToList();
 
-            
             #region SupportingСurrentBehavior for Config Clone and Fork 
 
-            if (type == typeof(MulticastDelegate))
-                return true;
+            //  if (type == typeof(MulticastDelegate))
+            //      return true;
 
-            if (type == typeof(TypeAdapterSetter))
-                return true;
-
-            //  if (type == typeof(TypeAdapterRule))
+            //if (type == typeof(TypeAdapterSetter))
             //    return true;
 
-            if (type == typeof(TypeAdapterSettings))
+            ////  if (type == typeof(TypeAdapterRule))
+            ////    return true;
+
+            //if (type == typeof(TypeAdapterSettings))
+            //    return true;
+
+            //if (type == typeof(TypeTuple))
+            //    return true;
+
+
+            if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(KeyValuePair<,>))
                 return true;
 
-            if (type.IsValueType && type?.GetConstructors().Length != 0)
-            {
-                var test = type.GetConstructors()[0].GetParameters();
-                var param = type.GetConstructors()[0].GetParameters().ToArray();
 
-                if (param[0]?.ParameterType == typeof(TypeTuple) && param[1]?.ParameterType == typeof(TypeAdapterRule))
-                    return true;
-            }
+            //if (type.IsValueType && type?.GetConstructors().Length != 0)
+            //{
+            //    var test = type.GetConstructors()[0].GetParameters();
+            //    var param = type.GetConstructors()[0].GetParameters().ToArray();
 
-            if (type == typeof(TypeTuple))
-                return true;
+            //    if (param[0]?.ParameterType == typeof(TypeTuple) && param[1]?.ParameterType == typeof(TypeAdapterRule))
+            //      return true;
+            //}
+
+            
 
             #endregion SupportingСurrentBehavior for Config Clone and Fork 
 

--- a/src/Mapster/Utils/ReflectionUtils.cs
+++ b/src/Mapster/Utils/ReflectionUtils.cs
@@ -171,44 +171,15 @@ namespace Mapster
 
             if(RecordTypeIdentityHelper.IsDirectiveTagret(type)) // added Support work from custom Attribute
                 return true;
-
-            var props = type.GetFieldsAndProperties().ToList();
-
+          
             #region SupportingСurrentBehavior for Config Clone and Fork 
-
-            //  if (type == typeof(MulticastDelegate))
-            //      return true;
-
-            //if (type == typeof(TypeAdapterSetter))
-            //    return true;
-
-            ////  if (type == typeof(TypeAdapterRule))
-            ////    return true;
-
-            //if (type == typeof(TypeAdapterSettings))
-            //    return true;
-
-            //if (type == typeof(TypeTuple))
-            //    return true;
-
 
             if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(KeyValuePair<,>))
                 return true;
 
-
-            //if (type.IsValueType && type?.GetConstructors().Length != 0)
-            //{
-            //    var test = type.GetConstructors()[0].GetParameters();
-            //    var param = type.GetConstructors()[0].GetParameters().ToArray();
-
-            //    if (param[0]?.ParameterType == typeof(TypeTuple) && param[1]?.ParameterType == typeof(TypeAdapterRule))
-            //      return true;
-            //}
-
-            
-
             #endregion SupportingСurrentBehavior for Config Clone and Fork 
 
+            var props = type.GetFieldsAndProperties().ToList();
 
             //interface with readonly props
             if (type.GetTypeInfo().IsInterface &&
@@ -217,7 +188,6 @@ namespace Mapster
 
            if(RecordTypeIdentityHelper.IsRecordType(type))
                 return true;
-
 
             return false;
         }


### PR DESCRIPTION
Fix Issue:
#501 - _test named OnlyInlineRecordWorked_ (regarding not filling the record with data in the given case)

Add 
1) (InlineExpression is Worked) Field Activation passing Field values not specified in the constructor when creating a new record instance
2) Record Creation on Default Passing Field values not specified in the constructor when creating a new record instance (Activation)
3) A special attribute to support custom classes (structures) that use the [current record definition](https://github.com/MapsterMapper/Mapster/wiki/Data-types#mappable-objects). _description  of spec record at the end of the page_ -
[AdaptWith(AdaptDirectives.DestinationAsRecord)] - **to be confirmed**

Example:
```
 [TestMethod]
        public void MultiCtorAndInlineRecordWorked()
        {
            var _sourcePoco = new MultiCtorAndInlinePoco() { MyInt = 1, MyString = "Hello", MyEmail = "123@gmail.com", InitData="Test"};
            var _sourceMultiCtorAndInline = new MultiCtorAndInlineRecord(2, "Hello World") { InitData = "Worked", MyEmail = "243@gmail.com" };

            var _resultMultiCtorAndInline = _sourcePoco.Adapt<MultiCtorAndInlineRecord>();  // Activation 
            var _updateResult = _sourceMultiCtorAndInline.Adapt(_resultMultiCtorAndInline);  // Update

            _resultMultiCtorAndInline.MyInt.ShouldBe(1);
            _resultMultiCtorAndInline.MyString.ShouldBe("Hello");
            _resultMultiCtorAndInline.MyEmail.ShouldBe("123@gmail.com");
            _resultMultiCtorAndInline.InitData.ShouldBe("Test");
            _updateResult.MyInt.ShouldBe(2);
            _updateResult.MyString.ShouldBe("Hello World");
            _updateResult.MyEmail.ShouldBe("243@gmail.com");
            _updateResult.InitData.ShouldBe("Worked");
        }

    record MultiCtorAndInlineRecord
    {
        public MultiCtorAndInlineRecord(int myInt)
        {
            MyInt = myInt;
        }

        public MultiCtorAndInlineRecord(int myInt, string myString) : this(myInt) // default have been using this constructor
        {
            MyString = myString;
        }


        public int MyInt { get; private set; } // private set only constructor or using init 
        public string MyString { get; private set; } // private set only constructor or using init 
        public string MyEmail { get; set; } 
        public string InitData { get; init; } // init in Constructor or inline activation
    }

```