### PR TITLE
Add support for primitive types in custom mapping

### DIFF
--- a/src/Mapster.Tests/WhenMappingPrimitiveCustomMappingRegression.cs
+++ b/src/Mapster.Tests/WhenMappingPrimitiveCustomMappingRegression.cs
@@ -64,7 +64,7 @@ namespace Mapster.Tests
               .MapWith(src => new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddSeconds(src).Date);
 
             var emptySource = new Source407() { Time = DateTime.UtcNow.Date };
-            var fromC1 = new DateTime(2023, 10, 27);
+            var fromC1 = new DateTime(2023, 10, 27,0,0,0,DateTimeKind.Utc);
             var fromC2 = new DateTimeOffset(new DateTime(2025, 11, 23,0,0,0,DateTimeKind.Utc)).ToUnixTimeSeconds();
             var c1 = new Source407 { Time = fromC1 };
             var c2 = new Destination407 { Time = fromC2 };
@@ -72,7 +72,7 @@ namespace Mapster.Tests
             var _result = c1.Adapt<Destination407>(); // Work 
             var _resultLongtoDateTime = c2.Adapt<Source407>();
 
-            _result.Time.ShouldBe(new DateTimeOffset(new DateTime(2023, 10, 27)).ToUnixTimeSeconds()); // Work                  
+            _result.Time.ShouldBe(new DateTimeOffset(new DateTime(2023, 10, 27, 0, 0, 0, DateTimeKind.Utc)).ToUnixTimeSeconds()); // Work                  
             _resultLongtoDateTime.Time.ShouldBe(new DateTime(2025, 11, 23).Date); // work but but it turns out to be a day less. Perhaps this is how it was intended
         }
 

--- a/src/Mapster.Tests/WhenMappingPrimitiveCustomMappingRegression.cs
+++ b/src/Mapster.Tests/WhenMappingPrimitiveCustomMappingRegression.cs
@@ -65,7 +65,7 @@ namespace Mapster.Tests
 
             var emptySource = new Source407() { Time = DateTime.UtcNow.Date };
             var fromC1 = new DateTime(2023, 10, 27);
-            var fromC2 = new DateTimeOffset(new DateTime(2025, 11, 23)).ToUnixTimeSeconds();
+            var fromC2 = new DateTimeOffset(new DateTime(2025, 11, 23,0,0,0,DateTimeKind.Utc)).ToUnixTimeSeconds();
             var c1 = new Source407 { Time = fromC1 };
             var c2 = new Destination407 { Time = fromC2 };
 
@@ -73,7 +73,7 @@ namespace Mapster.Tests
             var _resultLongtoDateTime = c2.Adapt<Source407>();
 
             _result.Time.ShouldBe(new DateTimeOffset(new DateTime(2023, 10, 27)).ToUnixTimeSeconds()); // Work                  
-            _resultLongtoDateTime.Time.ShouldBe(new DateTime(2025, 11, 22).Date); // work but but it turns out to be a day less. Perhaps this is how it was intended
+            _resultLongtoDateTime.Time.ShouldBe(new DateTime(2025, 11, 23).Date); // work but but it turns out to be a day less. Perhaps this is how it was intended
         }
 
     }

--- a/src/Mapster.Tests/WhenMappingPrimitiveCustomMappingRegression.cs
+++ b/src/Mapster.Tests/WhenMappingPrimitiveCustomMappingRegression.cs
@@ -7,6 +7,7 @@ namespace Mapster.Tests
     [TestClass]
     public class WhenMappingPrimitiveCustomMappingRegression
     {
+        [TestMethod]
         public void CustomMappingDateTimeToPrimitive()
         {
             TypeAdapterConfig<DateTime, long>
@@ -22,7 +23,9 @@ namespace Mapster.Tests
             var _resultToLong = _source.Adapt<long>();
             var _resultToString = _source.Adapt<string>();
 
-
+            _resultToLong.ShouldBe(new DateTimeOffset(new DateTime(2023, 10, 27)).ToUnixTimeSeconds());
+            _resultToString.ShouldNotBe(_source.ToString());
+            _resultToString.ShouldBe(_source.ToShortDateString());
         }
 
         /// <summary>

--- a/src/Mapster.Tests/WhenMappingPrimitiveCustomMappingRegression.cs
+++ b/src/Mapster.Tests/WhenMappingPrimitiveCustomMappingRegression.cs
@@ -18,12 +18,12 @@ namespace Mapster.Tests
                .NewConfig()
                .MapWith(src => src.ToShortDateString());
 
-            var _source = new DateTime(2023, 10, 27);
+            var _source = new DateTime(2023, 10, 27, 0, 0, 0, DateTimeKind.Utc);
 
             var _resultToLong = _source.Adapt<long>();
             var _resultToString = _source.Adapt<string>();
 
-            _resultToLong.ShouldBe(new DateTimeOffset(new DateTime(2023, 10, 27)).ToUnixTimeSeconds());
+            _resultToLong.ShouldBe(new DateTimeOffset(new DateTime(2023, 10, 27, 0, 0, 0, DateTimeKind.Utc)).ToUnixTimeSeconds());
             _resultToString.ShouldNotBe(_source.ToString());
             _resultToString.ShouldBe(_source.ToShortDateString());
         }
@@ -65,15 +65,15 @@ namespace Mapster.Tests
 
             var emptySource = new Source407() { Time = DateTime.UtcNow.Date };
             var fromC1 = new DateTime(2023, 10, 27,0,0,0,DateTimeKind.Utc);
-            var fromC2 = new DateTimeOffset(new DateTime(2025, 11, 23,0,0,0,DateTimeKind.Utc)).ToUnixTimeSeconds();
+            var fromC2 = new DateTimeOffset(new DateTime(2025, 11, 23, 0, 0, 0, DateTimeKind.Utc)).ToUnixTimeSeconds();
             var c1 = new Source407 { Time = fromC1 };
             var c2 = new Destination407 { Time = fromC2 };
 
             var _result = c1.Adapt<Destination407>(); // Work 
             var _resultLongtoDateTime = c2.Adapt<Source407>();
 
-            _result.Time.ShouldBe(new DateTimeOffset(new DateTime(2023, 10, 27, 0, 0, 0, DateTimeKind.Utc)).ToUnixTimeSeconds()); // Work                  
-            _resultLongtoDateTime.Time.ShouldBe(new DateTime(2025, 11, 23).Date); // work but but it turns out to be a day less. Perhaps this is how it was intended
+            _result.Time.ShouldBe(new DateTimeOffset(new DateTime(2023, 10, 27, 0, 0, 0, DateTimeKind.Utc)).ToUnixTimeSeconds());               
+            _resultLongtoDateTime.Time.ShouldBe(new DateTime(2025, 11, 23).Date);
         }
 
     }

--- a/src/Mapster.Tests/WhenMappingPrimitiveCustomMappingRegression.cs
+++ b/src/Mapster.Tests/WhenMappingPrimitiveCustomMappingRegression.cs
@@ -1,0 +1,116 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Shouldly;
+using System;
+
+namespace Mapster.Tests
+{
+    [TestClass]
+    public class WhenMappingPrimitiveCustomMappingRegression
+    {
+        public void CustomMappingDateTimeToPrimitive()
+        {
+            TypeAdapterConfig<DateTime, long>
+               .NewConfig()
+               .MapWith(src => new DateTimeOffset(src).ToUnixTimeSeconds());
+
+            TypeAdapterConfig<DateTime, string>
+               .NewConfig()
+               .MapWith(src => src.ToShortDateString());
+
+            var _source = new DateTime(2023, 10, 27);
+
+            var _resultToLong = _source.Adapt<long>();
+            var _resultToString = _source.Adapt<string>();
+
+
+        }
+
+        /// <summary>
+        /// https://github.com/MapsterMapper/Mapster/issues/561
+        /// </summary>
+        [TestMethod]
+        public void MappingToPrimitiveInsiderWithCustomMapping()
+        {
+            TypeAdapterConfig<Optional561<string?>, string?>
+                .NewConfig()
+                .MapToTargetWith((source, target) => source.HasValue ? source.Value : target);
+
+            var sourceNull = new Source561 { Name = new Optional561<string?>(null) };
+            var target = new Source561 { Name = new Optional561<string>("John") }.Adapt<Target561>();
+
+            var TargetDestinationFromNull = new Target561() { Name = "Me" };
+            var NullToupdateoptional = sourceNull.Adapt(TargetDestinationFromNull);
+            var _result = sourceNull.Adapt(target);
+
+            target.Name.ShouldBe("John");
+            NullToupdateoptional.Name.ShouldBe("Me");
+        }
+
+        /// <summary>
+        /// https://github.com/MapsterMapper/Mapster/issues/407
+        /// </summary>
+        [TestMethod]
+        public void MappingDatetimeToLongWithCustomMapping()
+        {
+            TypeAdapterConfig<DateTime, long>
+               .NewConfig()
+               .MapWith(src => new DateTimeOffset(src).ToUnixTimeSeconds());
+
+            TypeAdapterConfig<long, DateTime>
+              .NewConfig()
+              .MapWith(src => new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddSeconds(src).Date);
+
+            var emptySource = new Source407() { Time = DateTime.UtcNow.Date };
+            var fromC1 = new DateTime(2023, 10, 27);
+            var fromC2 = new DateTimeOffset(new DateTime(2025, 11, 23)).ToUnixTimeSeconds();
+            var c1 = new Source407 { Time = fromC1 };
+            var c2 = new Destination407 { Time = fromC2 };
+
+            var _result = c1.Adapt<Destination407>(); // Work 
+            var _resultLongtoDateTime = c2.Adapt<Source407>();
+
+            _result.Time.ShouldBe(new DateTimeOffset(new DateTime(2023, 10, 27)).ToUnixTimeSeconds()); // Work                  
+            _resultLongtoDateTime.Time.ShouldBe(new DateTime(2025, 11, 22).Date); // work but but it turns out to be a day less. Perhaps this is how it was intended
+        }
+
+    }
+
+
+    #region TestClasses
+
+    public class Source407
+    {
+        public DateTime Time { get; set; }
+    }
+
+    public class Destination407
+    {
+        public long Time { get; set; }
+    }
+
+    class Optional561<T>
+    {
+        public Optional561(T? value)
+        {
+            if (value != null)
+                HasValue = true;
+
+            Value = value;
+        }
+
+        public bool HasValue { get; }
+        public T? Value { get; }
+    }
+
+    class Source561
+    {
+        public Optional561<string?> Name { get; set; }
+    }
+
+    class Target561
+    {
+        public string? Name { get; set; }
+    }
+
+    #endregion TestClasses
+}

--- a/src/Mapster/Adapters/BaseAdapter.cs
+++ b/src/Mapster/Adapters/BaseAdapter.cs
@@ -85,6 +85,32 @@ namespace Mapster.Adapters
             if (CheckExplicitMapping && arg.Context.Config.RequireExplicitMapping && !arg.ExplicitMapping)
                 throw new InvalidOperationException("Implicit mapping is not allowed (check GlobalSettings.RequireExplicitMapping) and no configuration exists");
 
+            #region CustomMappingPrimitiveImplimentation
+
+            if (arg.Settings.MapToTargetPrimitive == true)
+            {
+                Expression dest;
+
+                if (destination == null)
+                {
+                    dest = arg.DestinationType.CreateDefault();
+                }
+                else
+                    dest = destination;
+
+                var customConvert = arg.Context.Config.CreateMapToTargetInvokeExpressionBody(source.Type, arg.DestinationType, source, dest);
+
+                arg.MapType = MapType.MapToTarget;
+                return customConvert;
+            }
+
+            if (arg.Settings.MapWithToPrimitive == true)
+            {
+                return arg.Context.Config.CreateMapInvokeExpressionBody(source.Type, arg.DestinationType, source);
+            }
+
+            #endregion CustomMappingPrimitiveImplimentation
+
             var oldMaxDepth = arg.Context.MaxDepth;
             var oldDepth = arg.Context.Depth;
             try

--- a/src/Mapster/Adapters/PrimitiveAdapter.cs
+++ b/src/Mapster/Adapters/PrimitiveAdapter.cs
@@ -18,6 +18,24 @@ namespace Mapster.Adapters
 
         protected override Expression CreateExpressionBody(Expression source, Expression? destination, CompileArgument arg)
         {
+
+            if (arg.Settings.MapToTargetPrimitive == true)
+            {
+                Expression dest;
+
+                if (destination == null)
+                {
+                    dest = arg.DestinationType.CreateDefault();
+                }
+                else
+                    dest = destination;
+
+                var customConvert = arg.Context.Config.CreateMapToTargetInvokeExpressionBody(source.Type, arg.DestinationType, source, dest);
+
+                arg.MapType = MapType.MapToTarget;
+                return customConvert;
+            }
+
             Expression convert = source;
             var sourceType = arg.SourceType;
             var destinationType = arg.DestinationType;

--- a/src/Mapster/TypeAdapterSetter.cs
+++ b/src/Mapster/TypeAdapterSetter.cs
@@ -611,6 +611,11 @@ namespace Mapster
         {
             this.CheckCompiled();
 
+            if(typeof(TSource).IsMapsterPrimitive() || typeof(TDestination).IsMapsterPrimitive())
+            {
+                this.Settings.MapWithToPrimitive = true;
+            }
+
             if (applySettings)
             {
                 var adapter = new DelegateAdapter(converterFactory);
@@ -633,6 +638,11 @@ namespace Mapster
         public TypeAdapterSetter<TSource, TDestination> MapToTargetWith(Expression<Func<TSource, TDestination, TDestination>> converterFactory, bool applySettings = false)
         {
             this.CheckCompiled();
+
+            if (typeof(TSource).IsMapsterPrimitive() || typeof(TDestination).IsMapsterPrimitive())
+            {
+                this.Settings.MapToTargetPrimitive = true;
+            }
 
             if (applySettings)
             {

--- a/src/Mapster/TypeAdapterSettings.cs
+++ b/src/Mapster/TypeAdapterSettings.cs
@@ -83,6 +83,27 @@ namespace Mapster
             set => Set(nameof(GenerateMapper), value);
         }
 
+        public bool? MapWithToPrimitive
+        {
+            get => Get(nameof(MapWithToPrimitive));
+            set => Set(nameof(MapWithToPrimitive), value);
+        }
+
+        /// <summary>
+        /// Not implemented
+        /// </summary>
+        public bool? MapToPrimitive
+        {
+            get => Get(nameof(MapToPrimitive));
+            set => Set(nameof(MapToPrimitive), value);
+        }
+
+        public bool? MapToTargetPrimitive
+        {
+            get => Get(nameof(MapToTargetPrimitive));
+            set => Set(nameof(MapToTargetPrimitive), value);
+        }
+
         public List<Func<IMemberModel, MemberSide, bool?>> ShouldMapMember
         {
             get => Get(nameof(ShouldMapMember), () => new List<Func<IMemberModel, MemberSide, bool?>>());

--- a/src/Mapster/Utils/ReflectionUtils.cs
+++ b/src/Mapster/Utils/ReflectionUtils.cs
@@ -36,6 +36,11 @@ namespace Mapster
         }
 #endif
 
+        public static bool IsMapsterPrimitive(this Type type)
+        {
+            return _primitiveTypes.TryGetValue(type, out var primitiveType) || type == typeof(string);
+        }
+
         public static bool IsNullable(this Type type)
         {
             return type.GetTypeInfo().IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>);


### PR DESCRIPTION
before:
When you mapping To primitive and string always using [converter logic](https://github.com/MapsterMapper/Mapster/wiki/Data-types#primitives) 

now You can use Custom Conversion logic 
supported:
.MapWith()
.MapToTargetWith()

Supporting primitive type from [source code](https://github.com/MapsterMapper/Mapster/blob/04ac871b55828c3909b6cee4764e6fab40db3983/src/Mapster/Utils/ReflectionUtils.cs#L15) 

> typeof(bool)
>  typeof(short)
>  typeof(int)
>  typeof(long)
>  typeof(float)
>  typeof(double)
>  typeof(decimal)
>  typeof(ushort)
>  typeof(uint)
>  typeof(ulong)
>  typeof(byte)
>  typeof(sbyte)
>  typeof(DateTime)
> +
> typeof(string)

Example:

```
[TestMethod]
public void CustomMappingDateTimeToPrimitive()
{
    TypeAdapterConfig<DateTime, long>
       .NewConfig()
       .MapWith(src => new DateTimeOffset(src).ToUnixTimeSeconds());

    TypeAdapterConfig<DateTime, string>
       .NewConfig()
       .MapWith(src => src.ToShortDateString());

    var _source = new DateTime(2023, 10, 27, 0, 0, 0, DateTimeKind.Utc);

    var _resultToLong = _source.Adapt<long>();
    var _resultToString = _source.Adapt<string>();

    _resultToLong.ShouldBe(new DateTimeOffset(new DateTime(2023, 10, 27, 0, 0, 0, DateTimeKind.Utc)).ToUnixTimeSeconds());
    _resultToString.ShouldNotBe(_source.ToString());
    _resultToString.ShouldBe(_source.ToShortDateString());
}

/// <summary>
/// https://github.com/MapsterMapper/Mapster/issues/407
/// </summary>
[TestMethod]
public void MappingDatetimeToLongWithCustomMapping()
{
    TypeAdapterConfig<DateTime, long>
       .NewConfig()
       .MapWith(src => new DateTimeOffset(src).ToUnixTimeSeconds());

    TypeAdapterConfig<long, DateTime>
      .NewConfig()
      .MapWith(src => new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddSeconds(src).Date);

    var emptySource = new Source407() { Time = DateTime.UtcNow.Date };
    var fromC1 = new DateTime(2023, 10, 27,0,0,0,DateTimeKind.Utc);
    var fromC2 = new DateTimeOffset(new DateTime(2025, 11, 23, 0, 0, 0, DateTimeKind.Utc)).ToUnixTimeSeconds();
    var c1 = new Source407 { Time = fromC1 };
    var c2 = new Destination407 { Time = fromC2 };

    var _result = c1.Adapt<Destination407>(); // Work 
    var _resultLongtoDateTime = c2.Adapt<Source407>();

    _result.Time.ShouldBe(new DateTimeOffset(new DateTime(2023, 10, 27, 0, 0, 0, DateTimeKind.Utc)).ToUnixTimeSeconds());               
    _resultLongtoDateTime.Time.ShouldBe(new DateTime(2025, 11, 23).Date);
}

```

