### PR TITLE
Fix Issue #656. Mapping init Property

### DIFF
--- a/src/Mapster.Tests/WhenMappingInitPropertyRegression.cs
+++ b/src/Mapster.Tests/WhenMappingInitPropertyRegression.cs
@@ -14,29 +14,29 @@ namespace Mapster.Tests
         [TestMethod]
         public void InitPropertyWorked()
         {
-            MapsterTest mapster = new MapsterTest();
+            MapsterTest656 mapster = new MapsterTest656();
 
             var from = new MyClass656 { MyProperty = 1 };
             var to = mapster.Mapper.Map<DtoClass656>(from);
 
-            to.MyPropertyDto.ShouldNotBe(1);
+            to.MyPropertyDto.ShouldBe(1);
         }
 
 
     }
 
     #region TestClasses
-    public class MapsterTest
+    public class MapsterTest656
     {
         public Mapper Mapper { get; }
 
         TypeAdapterConfig config;
 
-        public MapsterTest()
+        public MapsterTest656()
         {
             config = new TypeAdapterConfig();
             config.Default.Settings.PreserveReference = true;
-            config.Scan(Assembly.GetAssembly(typeof(MapsterTest)));
+            config.Scan(Assembly.GetAssembly(typeof(MapsterTest656)));
             config.Compile();
             Mapper = new Mapper(config);
         }
@@ -49,7 +49,7 @@ namespace Mapster.Tests
 
     public class DtoClass656
     {
-        public int MyPropertyDto { get; protected init; }
+        public int MyPropertyDto { get; init; }
     }
     internal class Register656 : IRegister
     {

--- a/src/Mapster.Tests/WhenMappingInitPropertyRegression.cs
+++ b/src/Mapster.Tests/WhenMappingInitPropertyRegression.cs
@@ -1,0 +1,64 @@
+﻿using MapsterMapper;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Shouldly;
+using System.Reflection;
+
+namespace Mapster.Tests
+{
+    [TestClass]
+    public class WhenMappingInitPropertyRegression
+    {
+        /// <summary>
+        /// https://github.com/MapsterMapper/Mapster/issues/656
+        /// </summary>
+        [TestMethod]
+        public void InitPropertyWorked()
+        {
+            MapsterTest mapster = new MapsterTest();
+
+            var from = new MyClass656 { MyProperty = 1 };
+            var to = mapster.Mapper.Map<DtoClass656>(from);
+
+            to.MyPropertyDto.ShouldNotBe(1);
+        }
+
+
+    }
+
+    #region TestClasses
+    public class MapsterTest
+    {
+        public Mapper Mapper { get; }
+
+        TypeAdapterConfig config;
+
+        public MapsterTest()
+        {
+            config = new TypeAdapterConfig();
+            config.Default.Settings.PreserveReference = true;
+            config.Scan(Assembly.GetAssembly(typeof(MapsterTest)));
+            config.Compile();
+            Mapper = new Mapper(config);
+        }
+    }
+
+    internal class MyClass656
+    {
+        public int MyProperty { get; set; }
+    }
+
+    public class DtoClass656
+    {
+        public int MyPropertyDto { get; protected init; }
+    }
+    internal class Register656 : IRegister
+    {
+        void IRegister.Register(TypeAdapterConfig config)
+        {
+            config.NewConfig<MyClass656, DtoClass656>()
+                .Map(x => x.MyPropertyDto, x => x.MyProperty);
+        }
+    }
+
+    #endregion TestClasses
+}

--- a/src/Mapster.Tests/WhenScanningForRegisters.cs
+++ b/src/Mapster.Tests/WhenScanningForRegisters.cs
@@ -16,7 +16,7 @@ namespace Mapster.Tests
         {
             var config = new TypeAdapterConfig();
             IList<IRegister> registers = config.Scan(Assembly.GetExecutingAssembly());
-            registers.Count.ShouldBe(2);
+            registers.Count.ShouldBe(3);
 
             var typeTuples = config.RuleMap.Keys.ToList();
 

--- a/src/Mapster/Adapters/ClassAdapter.cs
+++ b/src/Mapster/Adapters/ClassAdapter.cs
@@ -150,18 +150,19 @@ namespace Mapster.Adapters
                     }
                     else
                     {
-                        //Todo Try catch block should be removed after pull request approved
-                        try
+                        var destinationPropertyInfo = (PropertyInfo)member.DestinationMember.Info!;
+
+                        if (!adapt.IsComplex() && arg.MapType == MapType.MapToTarget)
                         {
-                            var destinationPropertyInfo = (PropertyInfo)member.DestinationMember.Info!;
-                            adapt = destinationPropertyInfo.IsInitOnly()
-                                ? SetValueByReflection(destination, (MemberExpression)adapt, arg.DestinationType)
-                                : member.DestinationMember.SetExpression(destination, adapt);
+                            if (arg.DestinationType.IsInterface || arg.DestinationType.IsCollectionCompatible())
+                                adapt = member.DestinationMember.SetExpression(destination, adapt);
+                            else if (destinationPropertyInfo.IsInitOnly() || destinationPropertyInfo.SetMethod.IsPublic == false)
+                                adapt = SetValueByReflection(destination, (MemberExpression)adapt, arg.DestinationType);
+                            else
+                                adapt = member.DestinationMember.SetExpression(destination, adapt);
                         }
-                        catch (Exception e)
-                        {
+                        else
                             adapt = member.DestinationMember.SetExpression(destination, adapt);
-                        }
                     }
                 }
                 else if (!adapt.IsComplex())


### PR DESCRIPTION
Fix Issue #656 

Partial fix  issue #422 
   Fix MapToTarget generation to not Public setters (init Prorperty also working in Mapster 7.4.0)
Not Fix AdaptTo - need use `.MapToConstructor(true)`;

example

```
public class SalesOrder
{
   public SalesOrder(){}
   public SalesOrder(Guid id, decimal total, string status)
    {
        Id = id;
        Total = total;
        Status = status;
    }

    public Guid Id { get; protected set; }
    public decimal Total { get; protected set; }
    public string Status { get; protected set; }
}

Bad generation :

public static SalesOrder AdaptToSalesOrder(this SalesOrderDto p1)
{
    return p1 == null ? null : new SalesOrder()
    {
        Id = p1.Id, 
        Total = p1.Total,
        Status = p1.Status
    };
}
```

when using `.MapToConstructor(true)`

 ```
Good generation :

public static SalesOrder AdaptToSalesOrder(this SalesOrderDto p1)
{
    return p1 == null ? null : new SalesOrder(p1.Id, p1.Total, p1.Status) {};
}



```