### PR TITLE
Use assembly loading context to isolate loaded assemblies from AppDomain #714

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,3 +181,8 @@ project.lock.json
 /src/.vs
 /.vs
 src/.idea
+
+# VS Code settings
+.vscode/launch.json
+.vscode/settings.json
+.vscode/tasks.json

--- a/src/Mapster.Tool/IsolatedAssemblyLoadContext.cs
+++ b/src/Mapster.Tool/IsolatedAssemblyLoadContext.cs
@@ -1,0 +1,47 @@
+using System;
+using System.IO;
+using System.Reflection;
+using System.Runtime.Loader;
+
+namespace Mapster.Tool
+{
+    public class IsolatedAssemblyContext : AssemblyLoadContext
+    {
+        private readonly AssemblyDependencyResolver resolver;
+
+        public IsolatedAssemblyContext(string assemblyPath)
+        {
+            resolver = new AssemblyDependencyResolver(assemblyPath);
+        }
+
+        protected override Assembly Load(AssemblyName assemblyName)
+        {
+            string assemblyPath = resolver.ResolveAssemblyToPath(assemblyName);
+            if (assemblyPath != null)
+            {
+                return LoadFromAssemblyPath(assemblyPath);
+            }
+
+            return null;
+        }
+
+        protected override IntPtr LoadUnmanagedDll(string unmanagedDllName)
+        {
+            string libraryPath = resolver.ResolveUnmanagedDllToPath(unmanagedDllName);
+            if (libraryPath != null)
+            {
+                return LoadUnmanagedDllFromPath(libraryPath);
+            }
+
+            return IntPtr.Zero;
+        }
+
+        public static Assembly LoadAssemblyFrom(string assemblyPath)
+        {
+            IsolatedAssemblyContext loadContext = new IsolatedAssemblyContext(assemblyPath);
+            return loadContext.LoadFromAssemblyName(
+                new AssemblyName(Path.GetFileNameWithoutExtension(assemblyPath))
+            );
+        }
+    }
+}

--- a/src/Mapster.Tool/Program.cs
+++ b/src/Mapster.Tool/Program.cs
@@ -60,7 +60,7 @@ namespace Mapster.Tool
 
         private static void GenerateMappers(MapperOptions opt)
         {
-            var assembly = Assembly.LoadFrom(Path.GetFullPath(opt.Assembly));
+            var assembly = IsolatedAssemblyContext.LoadAssemblyFrom(Path.GetFullPath(opt.Assembly));
             var config = TypeAdapterConfig.GlobalSettings;
             config.SelfContainedCodeGeneration = true;
             config.Scan(assembly);
@@ -150,7 +150,7 @@ namespace Mapster.Tool
 
         private static void GenerateModels(ModelOptions opt)
         {
-            var assembly = Assembly.LoadFrom(Path.GetFullPath(opt.Assembly));
+            var assembly = IsolatedAssemblyContext.LoadAssemblyFrom(Path.GetFullPath(opt.Assembly));
             var codeGenConfig = new CodeGenerationConfig();
             codeGenConfig.Scan(assembly);
 
@@ -381,7 +381,7 @@ namespace Mapster.Tool
 
         private static void GenerateExtensions(ExtensionOptions opt)
         {
-            var assembly = Assembly.LoadFrom(Path.GetFullPath(opt.Assembly));
+            var assembly = IsolatedAssemblyContext.LoadAssemblyFrom(Path.GetFullPath(opt.Assembly));
             var config = TypeAdapterConfig.GlobalSettings;
             config.SelfContainedCodeGeneration = true;
             config.Scan(assembly);


### PR DESCRIPTION
See issue #714 

I was running into issues running Mapster.Tool against projects with .NET 9 preview assemblies references (either directly or transitively from other dependencies.)

After sleuthing through dotnet/runtime CLR code I ran into this issue which seemed pertinent:

https://github.com/dotnet/runtime/discussions/102981

This PR is based off of recommendations by @jkotas there about how to load assemblies in an isolated way. It appears to have solved my issue with Mapster.Tool 8.4.1-pre01 mentioned.