### PR TITLE
Fix Issue #456 #707 #723 - Ignore() processing improvements

### DIFF
--- a/src/Mapster.Tests/WhenIgnoreMapping.cs
+++ b/src/Mapster.Tests/WhenIgnoreMapping.cs
@@ -90,7 +90,47 @@ namespace Mapster.Tests
             mapTotarget.Text.ShouldBe("test");
         }
 
+        /// <summary>
+        /// https://github.com/MapsterMapper/Mapster/issues/723
+        /// </summary>
+        [TestMethod]
+        public void MappingToIntefaceWithIgnorePrivateSetProperty()
+        {
+            TypeAdapterConfig<InterfaceSource723, InterfaceDestination723>
+                .NewConfig()
+                .TwoWays()
+                .Ignore(dest => dest.Ignore);
+
+            InterfaceDestination723 dataDestination = new Data723() { Inter = "IterDataDestination", Ignore = "IgnoreDataDestination" };
+
+            Should.NotThrow(() =>
+            {
+                var isourse = dataDestination.Adapt<InterfaceSource723>();
+                var idestination = dataDestination.Adapt<InterfaceDestination723>();
+            });
+
+        }
+
         #region TestClasses
+
+        public interface InterfaceDestination723
+        {
+            public string Inter { get; set; }
+            public string Ignore { get; }
+        }
+
+        public interface InterfaceSource723
+        {
+            public string Inter { get; set; }
+        }
+
+        private class Data723 : InterfaceSource723, InterfaceDestination723
+        {
+            public string Ignore { get; set; }
+
+            public string Inter { get; set; }
+        }
+
         static ConstructorInfo? GetConstructor<TDestination>()
         {
             var parameterlessCtorInfo = typeof(TDestination).GetConstructor(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public, new Type[0]);

--- a/src/Mapster.Tests/WhenMappingRecordRegression.cs
+++ b/src/Mapster.Tests/WhenMappingRecordRegression.cs
@@ -353,6 +353,25 @@ namespace Mapster.Tests
 
         }
 
+        /// <summary>
+        /// https://github.com/MapsterMapper/Mapster/issues/456
+        /// </summary>
+        [TestMethod]
+        public void WhenRecordReceivedIgnoreCtorParamProcessing()
+        {
+            TypeAdapterConfig<UserDto456,UserRecord456>.NewConfig()
+             .Ignore(dest => dest.Name);
+
+            var userDto = new UserDto456("Amichai");
+            var user = new UserRecord456("John");
+
+            var map = userDto.Adapt<UserRecord456>();
+            var maptoTarget = userDto.Adapt(user);
+
+            map.Name.ShouldBeNullOrEmpty();
+            maptoTarget.Name.ShouldBe("John");
+        }
+
 
 
         #region NowNotWorking
@@ -381,6 +400,11 @@ namespace Mapster.Tests
 
 
     #region TestClasses
+
+
+    public record UserRecord456(string Name);
+
+    public record UserDto456(string Name);
 
     public interface IActivityDataExtentions : IActivityData
     {

--- a/src/Mapster/Adapters/BaseClassAdapter.cs
+++ b/src/Mapster/Adapters/BaseClassAdapter.cs
@@ -15,7 +15,7 @@ namespace Mapster.Adapters
 
         #region Build the Adapter Model
 
-        protected ClassMapping CreateClassConverter(Expression source, ClassModel classModel, CompileArgument arg, Expression? destination = null, bool CtorMapping = false)
+        protected ClassMapping CreateClassConverter(Expression source, ClassModel classModel, CompileArgument arg, Expression? destination = null, bool ctorMapping = false)
         {
             var destinationMembers = classModel.Members;
             var unmappedDestinationMembers = new List<string>();
@@ -29,7 +29,7 @@ namespace Mapster.Adapters
                         : ExpressionEx.PropertyOrFieldPath(source, (string)src)));
             foreach (var destinationMember in destinationMembers)
             {
-                if (ProcessIgnores(arg, destinationMember, out var ignore) && !CtorMapping)
+                if (ProcessIgnores(arg, destinationMember, out var ignore) && !ctorMapping)
                     continue;
 
                 var resolvers = arg.Settings.ValueAccessingStrategies.AsEnumerable();

--- a/src/Mapster/Adapters/BaseClassAdapter.cs
+++ b/src/Mapster/Adapters/BaseClassAdapter.cs
@@ -158,25 +158,18 @@ namespace Mapster.Adapters
                         getter = Expression.Condition(condition, getter, defaultConst);
                     }
                     else
-                        if (arg.Settings.Ignore.Count != 0)
+                        if (arg.Settings.Ignore.Any(x => x.Key == member.DestinationMember.Name))
                     {
-                        if (arg.MapType != MapType.MapToTarget && arg.Settings.Ignore.Any(x => x.Key == member.DestinationMember.Name))
-                            getter = defaultConst;
+                        getter = defaultConst;
 
                         if (arg.MapType == MapType.MapToTarget && arg.DestinationType.IsRecordType())
                         {
-                            if (arg.Settings.Ignore.Any(x => x.Key == member.DestinationMember.Name))
-                            {
-                                var find = arg.DestinationType.GetFieldsAndProperties(arg.Settings.EnableNonPublicMembers.GetValueOrDefault()).ToArray()
-                                    .Where(x => x.Name == member.DestinationMember.Name).FirstOrDefault();
+                            var find = arg.DestinationType.GetFieldsAndProperties(arg.Settings.EnableNonPublicMembers.GetValueOrDefault()).ToArray()
+                                .Where(x => x.Name == member.DestinationMember.Name).FirstOrDefault();
 
-                                if (find != null)
-                                    getter = Expression.MakeMemberAccess(destination, (MemberInfo)find.Info);
-                            }
-                            else
-                                getter = defaultConst;
+                            if (find != null)
+                                getter = Expression.MakeMemberAccess(destination, (MemberInfo)find.Info);
                         }
-
                     }
                 }
                 arguments.Add(getter);

--- a/src/Mapster/Adapters/ClassAdapter.cs
+++ b/src/Mapster/Adapters/ClassAdapter.cs
@@ -69,13 +69,13 @@ namespace Mapster.Adapters
                 classConverter = destType.GetConstructors()
                     .OrderByDescending(it => it.GetParameters().Length)
                     .Select(it => GetConstructorModel(it, true))
-                    .Select(it => CreateClassConverter(source, it, arg, CtorMapping:true))
+                    .Select(it => CreateClassConverter(source, it, arg, ctorMapping:true))
                     .FirstOrDefault(it => it != null);
             }
             else
             {
                 var model = GetConstructorModel(ctor, false);
-                classConverter = CreateClassConverter(source, model, arg, CtorMapping:true);
+                classConverter = CreateClassConverter(source, model, arg, ctorMapping:true);
             }
 
             if (classConverter == null)

--- a/src/Mapster/Adapters/ClassAdapter.cs
+++ b/src/Mapster/Adapters/ClassAdapter.cs
@@ -69,19 +69,19 @@ namespace Mapster.Adapters
                 classConverter = destType.GetConstructors()
                     .OrderByDescending(it => it.GetParameters().Length)
                     .Select(it => GetConstructorModel(it, true))
-                    .Select(it => CreateClassConverter(source, it, arg))
+                    .Select(it => CreateClassConverter(source, it, arg, CtorMapping:true))
                     .FirstOrDefault(it => it != null);
             }
             else
             {
                 var model = GetConstructorModel(ctor, false);
-                classConverter = CreateClassConverter(source, model, arg);
+                classConverter = CreateClassConverter(source, model, arg, CtorMapping:true);
             }
 
             if (classConverter == null)
                 return base.CreateInstantiationExpression(source, destination, arg);
 
-            return CreateInstantiationExpression(source, classConverter, arg);
+            return CreateInstantiationExpression(source, classConverter, arg, destination);
         }
 
         protected override Expression CreateBlockExpression(Expression source, Expression destination, CompileArgument arg)

--- a/src/Mapster/Adapters/ReadOnlyInterfaceAdapter.cs
+++ b/src/Mapster/Adapters/ReadOnlyInterfaceAdapter.cs
@@ -39,7 +39,7 @@ namespace Mapster.Adapters
                 var ctor = destType.GetConstructors()[0];
                 var classModel = GetConstructorModel(ctor, false);
                 var classConverter = CreateClassConverter(source, classModel, arg);
-                return CreateInstantiationExpression(source, classConverter, arg);
+                return CreateInstantiationExpression(source, classConverter, arg, destination);
             }
             else
                 return base.CreateInstantiationExpression(source,destination, arg);

--- a/src/Mapster/Adapters/ReadOnlyInterfaceAdapter.cs
+++ b/src/Mapster/Adapters/ReadOnlyInterfaceAdapter.cs
@@ -38,7 +38,7 @@ namespace Mapster.Adapters
                     return base.CreateInstantiationExpression(source, destination, arg);
                 var ctor = destType.GetConstructors()[0];
                 var classModel = GetConstructorModel(ctor, false);
-                var classConverter = CreateClassConverter(source, classModel, arg);
+                var classConverter = CreateClassConverter(source, classModel, arg,CtorMapping:true);
                 return CreateInstantiationExpression(source, classConverter, arg, destination);
             }
             else

--- a/src/Mapster/Adapters/ReadOnlyInterfaceAdapter.cs
+++ b/src/Mapster/Adapters/ReadOnlyInterfaceAdapter.cs
@@ -38,7 +38,7 @@ namespace Mapster.Adapters
                     return base.CreateInstantiationExpression(source, destination, arg);
                 var ctor = destType.GetConstructors()[0];
                 var classModel = GetConstructorModel(ctor, false);
-                var classConverter = CreateClassConverter(source, classModel, arg,CtorMapping:true);
+                var classConverter = CreateClassConverter(source, classModel, arg, ctorMapping:true);
                 return CreateInstantiationExpression(source, classConverter, arg, destination);
             }
             else

--- a/src/Mapster/Adapters/RecordTypeAdapter.cs
+++ b/src/Mapster/Adapters/RecordTypeAdapter.cs
@@ -31,7 +31,7 @@ namespace Mapster.Adapters
             var ctor = destType.GetConstructors()
                     .OrderByDescending(it => it.GetParameters().Length).ToArray().FirstOrDefault(); // Will be used public constructor with the maximum number of parameters 
             var classModel = GetConstructorModel(ctor, false);
-            var classConverter = CreateClassConverter(source, classModel, arg, CtorMapping:true);
+            var classConverter = CreateClassConverter(source, classModel, arg, ctorMapping:true);
             var installExpr = CreateInstantiationExpression(source, classConverter, arg, destination);
             return RecordInlineExpression(source, arg, installExpr); // Activator field when not include in public ctor
         }

--- a/src/Mapster/Adapters/RecordTypeAdapter.cs
+++ b/src/Mapster/Adapters/RecordTypeAdapter.cs
@@ -31,8 +31,8 @@ namespace Mapster.Adapters
             var ctor = destType.GetConstructors()
                     .OrderByDescending(it => it.GetParameters().Length).ToArray().FirstOrDefault(); // Will be used public constructor with the maximum number of parameters 
             var classModel = GetConstructorModel(ctor, false);
-            var classConverter = CreateClassConverter(source, classModel, arg);
-            var installExpr = CreateInstantiationExpression(source, classConverter, arg);
+            var classConverter = CreateClassConverter(source, classModel, arg, CtorMapping:true);
+            var installExpr = CreateInstantiationExpression(source, classConverter, arg, destination);
             return RecordInlineExpression(source, arg, installExpr); // Activator field when not include in public ctor
         }
 


### PR DESCRIPTION
#456  When explicitly set to ignore():

1. Instance of a class can be created with default values ​​for parameters.
2. Explicitly set to ignore()  not mark param as not matched when config `RequireDestinationMemberSource = true,`

#707 #723  RecordTypes and Generated Type to Interface received support Ignore() from Ctor parameters