### PR TITLE
FIx Issue #537 - Step 4  - Fix MapToTarget behavior From RecordType

### DIFF
--- a/src/Mapster/Adapters/BaseClassAdapter.cs
+++ b/src/Mapster/Adapters/BaseClassAdapter.cs
@@ -54,6 +54,15 @@ namespace Mapster.Adapters
                     Destination = (ParameterExpression?)destination,
                     UseDestinationValue = arg.MapType != MapType.Projection && destinationMember.UseDestinationValue(arg),
                 };
+                if (arg.MapType == MapType.MapToTarget && getter == null && arg.DestinationType.IsRecordType())
+                {
+                    var find = arg.DestinationType.GetFieldsAndProperties(arg.Settings.EnableNonPublicMembers.GetValueOrDefault()).ToArray()
+                                .Where(x => x.Name == destinationMember.Name).FirstOrDefault();
+
+                    if (find != null)
+                        getter = Expression.MakeMemberAccess(destination, (MemberInfo)find.Info);
+
+                }
                 if (getter != null)
                 {
                     propertyModel.Getter = arg.MapType == MapType.Projection 

--- a/src/Mapster/Adapters/RecordTypeAdapter.cs
+++ b/src/Mapster/Adapters/RecordTypeAdapter.cs
@@ -33,7 +33,7 @@ namespace Mapster.Adapters
             var classModel = GetConstructorModel(ctor, false);
             var classConverter = CreateClassConverter(source, classModel, arg);
             var installExpr = CreateInstantiationExpression(source, classConverter, arg);
-            return RecordInlineExpression(source, arg, installExpr); // Activator field when not include in public ctor
+            return RecordInlineExpression(source, destination, arg, installExpr); // Activator field when not include in public ctor
         }
 
         protected override Expression CreateBlockExpression(Expression source, Expression destination, CompileArgument arg)
@@ -46,7 +46,7 @@ namespace Mapster.Adapters
             return base.CreateInstantiationExpression(source, arg);
         }
 
-        private Expression? RecordInlineExpression(Expression source, CompileArgument arg, Expression installExpr)
+        private Expression? RecordInlineExpression(Expression source, Expression? destination,  CompileArgument arg, Expression installExpr)
         {
             //new TDestination {
             //  Prop1 = convert(src.Prop1),
@@ -58,7 +58,7 @@ namespace Mapster.Adapters
             var newInstance = memberInit?.NewExpression ?? (NewExpression)exp;
             var contructorMembers = newInstance.Arguments.OfType<MemberExpression>().Select(me => me.Member).ToArray();
             var classModel = GetSetterModel(arg);
-            var classConverter = CreateClassConverter(source, classModel, arg);
+            var classConverter = CreateClassConverter(source, classModel, arg, destination:destination);
             var members = classConverter.Members;
 
             var lines = new List<MemberBinding>();


### PR DESCRIPTION
before  from 
```
record TestRecord()
{
    public int X { set; get; }
}
record TestRecordY() 
{
    public int X { set; get; }
    public int Y { set; get; }
}

var source = new TestRecord() { X= 200};
var dest = new TestRecordY() {X = 100, Y= 500}

```

```
var adapt = source.Adapt(dest)  // always adapt == { X=200, Y=0}
```

after 

```
var adapt = source.Adapt(dest)  // adapt == { X=200, Y=500}  Correct MapTotarget
```

equal behavior when modified using with 

```
var adapt = dest with {X=source.X};
```