### PR TITLE
Improvements to Ignore() processing and Fix MapToTarget behavior for RecordTypes 

### DIFF
--- a/src/Mapster.Tests/WhenIgnoreMapping.cs
+++ b/src/Mapster.Tests/WhenIgnoreMapping.cs
@@ -90,7 +90,47 @@ namespace Mapster.Tests
             mapTotarget.Text.ShouldBe("test");
         }
 
+        /// <summary>
+        /// https://github.com/MapsterMapper/Mapster/issues/723
+        /// </summary>
+        [TestMethod]
+        public void MappingToIntefaceWithIgnorePrivateSetProperty()
+        {
+            TypeAdapterConfig<InterfaceSource723, InterfaceDestination723>
+                .NewConfig()
+                .TwoWays()
+                .Ignore(dest => dest.Ignore);
+
+            InterfaceDestination723 dataDestination = new Data723() { Inter = "IterDataDestination", Ignore = "IgnoreDataDestination" };
+
+            Should.NotThrow(() =>
+            {
+                var isourse = dataDestination.Adapt<InterfaceSource723>();
+                var idestination = dataDestination.Adapt<InterfaceDestination723>();
+            });
+
+        }
+
         #region TestClasses
+
+        public interface InterfaceDestination723
+        {
+            public string Inter { get; set; }
+            public string Ignore { get; }
+        }
+
+        public interface InterfaceSource723
+        {
+            public string Inter { get; set; }
+        }
+
+        private class Data723 : InterfaceSource723, InterfaceDestination723
+        {
+            public string Ignore { get; set; }
+
+            public string Inter { get; set; }
+        }
+
         static ConstructorInfo? GetConstructor<TDestination>()
         {
             var parameterlessCtorInfo = typeof(TDestination).GetConstructor(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public, new Type[0]);

--- a/src/Mapster.Tests/WhenIgnoringConditionally.cs
+++ b/src/Mapster.Tests/WhenIgnoringConditionally.cs
@@ -164,6 +164,8 @@ namespace Mapster.Tests
                 .Compile();
 
             var poco = new SimplePoco { Id = 1, Name = "TestName" };
+
+            var srt = poco.BuildAdapter().CreateMapToTargetExpression<SimpleRecord>();
             var dto = TypeAdapter.Adapt<SimplePoco, SimpleRecord>(poco);
 
             dto.Id.ShouldBe(1);
@@ -190,8 +192,8 @@ namespace Mapster.Tests
         [AdaptWith(AdaptDirectives.DestinationAsRecord)]
         public class SimpleRecord
         {
-            public int Id { get; }
-            public string Name { get; }
+            public int Id { get; private set; }
+            public string Name { get; private set; }
 
             public SimpleRecord(int id, string name)
             {

--- a/src/Mapster.Tests/WhenMappingRecordRegression.cs
+++ b/src/Mapster.Tests/WhenMappingRecordRegression.cs
@@ -353,6 +353,25 @@ namespace Mapster.Tests
 
         }
 
+        /// <summary>
+        /// https://github.com/MapsterMapper/Mapster/issues/456
+        /// </summary>
+        [TestMethod]
+        public void WhenRecordReceivedIgnoreCtorParamProcessing()
+        {
+            TypeAdapterConfig<UserDto456,UserRecord456>.NewConfig()
+             .Ignore(dest => dest.Name);
+
+            var userDto = new UserDto456("Amichai");
+            var user = new UserRecord456("John");
+
+            var map = userDto.Adapt<UserRecord456>();
+            var maptoTarget = userDto.Adapt(user);
+
+            map.Name.ShouldBeNullOrEmpty();
+            maptoTarget.Name.ShouldBe("John");
+        }
+
 
 
         #region NowNotWorking
@@ -381,6 +400,11 @@ namespace Mapster.Tests
 
 
     #region TestClasses
+
+
+    public record UserRecord456(string Name);
+
+    public record UserDto456(string Name);
 
     public interface IActivityDataExtentions : IActivityData
     {

--- a/src/Mapster.Tests/WhenMappingRecordRegression.cs
+++ b/src/Mapster.Tests/WhenMappingRecordRegression.cs
@@ -18,9 +18,6 @@ namespace Mapster.Tests
                 .NewConfig()
                 .Ignore(dest => dest.Y);
 
-               
-
-
             var _source = new TestRecord() { X = 700 };
             var _destination = new TestRecordY() { X = 500 , Y = 200 };
 
@@ -29,9 +26,9 @@ namespace Mapster.Tests
 
             var result2 = _destination.Adapt(_destination2);
 
-            //_result.X.ShouldBe(700);
-            //_result.Y.ShouldBe(200);
-            //object.ReferenceEquals(_result, _destination).ShouldBeFalse();
+            _result.X.ShouldBe(700);
+            _result.Y.ShouldBe(200);
+            object.ReferenceEquals(_result, _destination).ShouldBeFalse();
         }
 
         [TestMethod]
@@ -374,28 +371,24 @@ namespace Mapster.Tests
             TypeAdapterConfig<UserDto456,UserRecord456>.NewConfig()
              .Ignore(dest => dest.Name);
 
-            //TypeAdapterConfig<DToInside, UserInside>.NewConfig()
-            //.Ignore(dest => dest.User);
+            TypeAdapterConfig<DtoInside, UserInside>.NewConfig()
+                .Ignore(dest => dest.User);
 
             var userDto = new UserDto456("Amichai");
             var user = new UserRecord456("John");
+            var DtoInsider = new DtoInside(userDto);
+            var UserInsider = new UserInside(user, new UserRecord456("Skot"));
 
-            //var map = userDto.Adapt<UserRecord456>();
+            var map = userDto.Adapt<UserRecord456>();
+            var maptoTarget = userDto.Adapt(user);
 
-           // var sd = userDto.BuildAdapter().CreateMapToTargetExpression<UserRecord456>();
-          //  var maptoTarget = userDto.Adapt(user);
+            var MapToTargetInsider = DtoInsider.Adapt(UserInsider);
 
+            map.Name.ShouldBeNullOrEmpty(); // Ignore is work set default value
+            maptoTarget.Name.ShouldBe("John"); // Ignore is work ignored member save value from Destination
+            MapToTargetInsider.User.Name.ShouldBe("John"); // Ignore is work member save value from Destination
+            MapToTargetInsider.SecondName.Name.ShouldBe("Skot"); // Unmached member save value from Destination
 
-            var s = new DToInside(userDto);
-
-            var d = new UserInside(user, new UserRecord456( "Skot"));
-
-            var sd = s.BuildAdapter().CreateMapToTargetExpression<UserInside>();
-
-            var ssd = s.Adapt(d);
-
-           // map.Name.ShouldBeNullOrEmpty();
-          //  maptoTarget.Name.ShouldBe("John");
         }
 
 
@@ -433,7 +426,7 @@ namespace Mapster.Tests
     }
 
     public record UserInside(UserRecord456 User, UserRecord456 SecondName);
-    public record DToInside(UserDto456 User);
+    public record DtoInside(UserDto456 User);
 
     public record UserRecord456(string Name);
 

--- a/src/Mapster.Tests/WhenMappingRecordRegression.cs
+++ b/src/Mapster.Tests/WhenMappingRecordRegression.cs
@@ -14,12 +14,24 @@ namespace Mapster.Tests
         [TestMethod]
         public void AdaptRecordToRecord()
         {
+            TypeAdapterConfig<TestRecordY, TestRecordY>
+                .NewConfig()
+                .Ignore(dest => dest.Y);
+
+               
+
+
             var _source = new TestRecord() { X = 700 };
             var _destination = new TestRecordY() { X = 500 , Y = 200 };
+
+            var _destination2 = new TestRecordY() { X = 300, Y = 400 };
             var _result = _source.Adapt(_destination);
-            _result.X.ShouldBe(700);
-            _result.Y.ShouldBe(200);
-            object.ReferenceEquals(_result, _destination).ShouldBeFalse();
+
+            var result2 = _destination.Adapt(_destination2);
+
+            //_result.X.ShouldBe(700);
+            //_result.Y.ShouldBe(200);
+            //object.ReferenceEquals(_result, _destination).ShouldBeFalse();
         }
 
         [TestMethod]
@@ -362,14 +374,28 @@ namespace Mapster.Tests
             TypeAdapterConfig<UserDto456,UserRecord456>.NewConfig()
              .Ignore(dest => dest.Name);
 
+            //TypeAdapterConfig<DToInside, UserInside>.NewConfig()
+            //.Ignore(dest => dest.User);
+
             var userDto = new UserDto456("Amichai");
             var user = new UserRecord456("John");
 
-            var map = userDto.Adapt<UserRecord456>();
-            var maptoTarget = userDto.Adapt(user);
+            //var map = userDto.Adapt<UserRecord456>();
 
-            map.Name.ShouldBeNullOrEmpty();
-            maptoTarget.Name.ShouldBe("John");
+           // var sd = userDto.BuildAdapter().CreateMapToTargetExpression<UserRecord456>();
+          //  var maptoTarget = userDto.Adapt(user);
+
+
+            var s = new DToInside(userDto);
+
+            var d = new UserInside(user, new UserRecord456( "Skot"));
+
+            var sd = s.BuildAdapter().CreateMapToTargetExpression<UserInside>();
+
+            var ssd = s.Adapt(d);
+
+           // map.Name.ShouldBeNullOrEmpty();
+          //  maptoTarget.Name.ShouldBe("John");
         }
 
 
@@ -405,6 +431,9 @@ namespace Mapster.Tests
         public int X { get; set; }
         public int Y { get; set; }
     }
+
+    public record UserInside(UserRecord456 User, UserRecord456 SecondName);
+    public record DToInside(UserDto456 User);
 
     public record UserRecord456(string Name);
 

--- a/src/Mapster.Tests/WhenMappingRecordRegression.cs
+++ b/src/Mapster.Tests/WhenMappingRecordRegression.cs
@@ -391,7 +391,36 @@ namespace Mapster.Tests
 
         }
 
+        [TestMethod]
+        public void WhenRecordTypeWorksWithUseDestinationValueAndIgnoreNullValues()
+        {
 
+            TypeAdapterConfig<SourceFromTestUseDestValue, TestRecordUseDestValue>
+              .NewConfig()
+              .IgnoreNullValues(true);
+
+            var _source = new SourceFromTestUseDestValue() { X = 300, Y = 200, Name = new StudentNameRecord() { Name = "John" } };
+            var result = _source.Adapt<TestRecordUseDestValue>();
+
+            var _sourceFromMapToTarget = new SourceFromTestUseDestValue() { A = 100, X = null, Y = null, Name = null };
+
+            var txt1 = _sourceFromMapToTarget.BuildAdapter().CreateMapExpression<TestRecordUseDestValue>();
+
+            var txt = _sourceFromMapToTarget.BuildAdapter().CreateMapToTargetExpression<TestRecordUseDestValue>();
+
+            var _resultMapToTarget = _sourceFromMapToTarget.Adapt(result);
+
+            result.A.ShouldBe(0);               // default Value - not match
+            result.S.ShouldBe("Inside Data");   // is not AutoProperty not mod by source
+            result.Y.ShouldBe(200);             // Y is AutoProperty value transmitted from source
+            result.Name.Name.ShouldBe("John");  // transmitted from source standart method
+
+            _resultMapToTarget.A.ShouldBe(100);
+            _resultMapToTarget.X.ShouldBe(300);            // Ignore NullValues work
+            _resultMapToTarget.Y.ShouldBe(200);            // Ignore NullValues work
+            _resultMapToTarget.Name.Name.ShouldBe("John"); // Ignore NullValues work
+
+        }
 
         #region NowNotWorking
 
@@ -419,6 +448,37 @@ namespace Mapster.Tests
 
 
     #region TestClasses
+    public class SourceFromTestUseDestValue
+    {
+        public int? A { get; set; }
+        public int? X { get; set; }
+        public int? Y { get; set; }
+        public StudentNameRecord Name { get; set; }
+    }
+
+
+    public record TestRecordUseDestValue()
+    {
+        private string _s = "Inside Data";
+
+        public int A { get; set; }
+        public int X { get; set; }
+
+        [UseDestinationValue]
+        public int Y { get; }
+
+        [UseDestinationValue]
+        public string S { get => _s; }
+
+        [UseDestinationValue]
+        public StudentNameRecord Name { get; } = new StudentNameRecord() { Name = "Marta" };
+    }
+
+    public record StudentNameRecord
+    {
+        public string Name { get; set; }
+    }
+
     public record TestRecordY()
     {
         public int X { get; set; }
@@ -723,15 +783,6 @@ namespace Mapster.Tests
     }
 
     sealed record TestSealedRecordPositional(int X);
-
-
-
-
-
-
-
-
-
 
     #endregion TestClasses
 }

--- a/src/Mapster/Adapters/BaseClassAdapter.cs
+++ b/src/Mapster/Adapters/BaseClassAdapter.cs
@@ -59,7 +59,7 @@ namespace Mapster.Adapters
                     var find = arg.DestinationType.GetFieldsAndProperties(arg.Settings.EnableNonPublicMembers.GetValueOrDefault()).ToArray()
                                 .Where(x => x.Name == destinationMember.Name).FirstOrDefault();
 
-                    if (find != null)
+                    if (find != null && destination != null)
                         getter = Expression.MakeMemberAccess(destination, (MemberInfo)find.Info);
 
                 }
@@ -154,6 +154,15 @@ namespace Mapster.Adapters
                 if (member.Getter == null)
                 {
                     getter = defaultConst;
+
+                    if (arg.MapType == MapType.MapToTarget && arg.DestinationType.IsRecordType())
+                    {
+                        var find = arg.DestinationType.GetFieldsAndProperties(arg.Settings.EnableNonPublicMembers.GetValueOrDefault()).ToArray()
+                                .Where(x => x.Name == member.DestinationMember.Name).FirstOrDefault();
+
+                        if (find != null && destination != null)
+                            getter = Expression.MakeMemberAccess(destination, (MemberInfo)find.Info);
+                    }
                 }
                 else
                 {

--- a/src/Mapster/Adapters/BaseClassAdapter.cs
+++ b/src/Mapster/Adapters/BaseClassAdapter.cs
@@ -15,7 +15,7 @@ namespace Mapster.Adapters
 
         #region Build the Adapter Model
 
-        protected ClassMapping CreateClassConverter(Expression source, ClassModel classModel, CompileArgument arg, Expression? destination = null, bool CtorMapping = false)
+        protected ClassMapping CreateClassConverter(Expression source, ClassModel classModel, CompileArgument arg, Expression? destination = null, bool ctorMapping = false)
         {
             var destinationMembers = classModel.Members;
             var unmappedDestinationMembers = new List<string>();
@@ -29,7 +29,7 @@ namespace Mapster.Adapters
                         : ExpressionEx.PropertyOrFieldPath(source, (string)src)));
             foreach (var destinationMember in destinationMembers)
             {
-                if (ProcessIgnores(arg, destinationMember, out var ignore) && !CtorMapping)
+                if (ProcessIgnores(arg, destinationMember, out var ignore) && !ctorMapping)
                     continue;
 
                 var resolvers = arg.Settings.ValueAccessingStrategies.AsEnumerable();

--- a/src/Mapster/Adapters/BaseClassAdapter.cs
+++ b/src/Mapster/Adapters/BaseClassAdapter.cs
@@ -158,25 +158,18 @@ namespace Mapster.Adapters
                         getter = Expression.Condition(condition, getter, defaultConst);
                     }
                     else
-                        if (arg.Settings.Ignore.Count != 0)
+                        if (arg.Settings.Ignore.Any(x => x.Key == member.DestinationMember.Name))
                     {
-                        if (arg.MapType != MapType.MapToTarget && arg.Settings.Ignore.Any(x => x.Key == member.DestinationMember.Name))
-                            getter = defaultConst;
+                        getter = defaultConst;
 
                         if (arg.MapType == MapType.MapToTarget && arg.DestinationType.IsRecordType())
                         {
-                            if (arg.Settings.Ignore.Any(x => x.Key == member.DestinationMember.Name))
-                            {
-                                var find = arg.DestinationType.GetFieldsAndProperties(arg.Settings.EnableNonPublicMembers.GetValueOrDefault()).ToArray()
-                                    .Where(x => x.Name == member.DestinationMember.Name).FirstOrDefault();
+                            var find = arg.DestinationType.GetFieldsAndProperties(arg.Settings.EnableNonPublicMembers.GetValueOrDefault()).ToArray()
+                                .Where(x => x.Name == member.DestinationMember.Name).FirstOrDefault();
 
-                                if (find != null)
-                                    getter = Expression.MakeMemberAccess(destination, (MemberInfo)find.Info);
-                            }
-                            else
-                                getter = defaultConst;
+                            if (find != null)
+                                getter = Expression.MakeMemberAccess(destination, (MemberInfo)find.Info);
                         }
-
                     }
                 }
                 arguments.Add(getter);

--- a/src/Mapster/Adapters/BaseClassAdapter.cs
+++ b/src/Mapster/Adapters/BaseClassAdapter.cs
@@ -197,7 +197,7 @@ namespace Mapster.Adapters
             };
         }
 
-        protected MemberExpression? TryRestoreRecordMember(IMemberModelEx member, ClassModel? restorRecordModel, Expression? destination)
+        protected Expression? TryRestoreRecordMember(IMemberModelEx member, ClassModel? restorRecordModel, Expression? destination)
         {
             if (restorRecordModel != null && destination != null)
             {
@@ -205,7 +205,11 @@ namespace Mapster.Adapters
                                .Where(x => x.Name == member.Name).FirstOrDefault();
 
                 if (find != null)
-                    return Expression.MakeMemberAccess(destination, (MemberInfo)find.Info);
+                {
+                    var compareNull = Expression.Equal(destination, Expression.Constant(null, destination.Type));
+                    return Expression.Condition(compareNull, member.Type.CreateDefault(), Expression.MakeMemberAccess(destination, (MemberInfo)find.Info));
+                }
+
             }
 
             return null;

--- a/src/Mapster/Adapters/ClassAdapter.cs
+++ b/src/Mapster/Adapters/ClassAdapter.cs
@@ -69,13 +69,13 @@ namespace Mapster.Adapters
                 classConverter = destType.GetConstructors()
                     .OrderByDescending(it => it.GetParameters().Length)
                     .Select(it => GetConstructorModel(it, true))
-                    .Select(it => CreateClassConverter(source, it, arg, CtorMapping:true))
+                    .Select(it => CreateClassConverter(source, it, arg, ctorMapping:true))
                     .FirstOrDefault(it => it != null);
             }
             else
             {
                 var model = GetConstructorModel(ctor, false);
-                classConverter = CreateClassConverter(source, model, arg, CtorMapping:true);
+                classConverter = CreateClassConverter(source, model, arg, ctorMapping:true);
             }
 
             if (classConverter == null)

--- a/src/Mapster/Adapters/ClassAdapter.cs
+++ b/src/Mapster/Adapters/ClassAdapter.cs
@@ -69,19 +69,19 @@ namespace Mapster.Adapters
                 classConverter = destType.GetConstructors()
                     .OrderByDescending(it => it.GetParameters().Length)
                     .Select(it => GetConstructorModel(it, true))
-                    .Select(it => CreateClassConverter(source, it, arg))
+                    .Select(it => CreateClassConverter(source, it, arg, CtorMapping:true))
                     .FirstOrDefault(it => it != null);
             }
             else
             {
                 var model = GetConstructorModel(ctor, false);
-                classConverter = CreateClassConverter(source, model, arg);
+                classConverter = CreateClassConverter(source, model, arg, CtorMapping:true);
             }
 
             if (classConverter == null)
                 return base.CreateInstantiationExpression(source, destination, arg);
 
-            return CreateInstantiationExpression(source, classConverter, arg);
+            return CreateInstantiationExpression(source, classConverter, arg, destination);
         }
 
         protected override Expression CreateBlockExpression(Expression source, Expression destination, CompileArgument arg)

--- a/src/Mapster/Adapters/ReadOnlyInterfaceAdapter.cs
+++ b/src/Mapster/Adapters/ReadOnlyInterfaceAdapter.cs
@@ -39,7 +39,7 @@ namespace Mapster.Adapters
                 var ctor = destType.GetConstructors()[0];
                 var classModel = GetConstructorModel(ctor, false);
                 var classConverter = CreateClassConverter(source, classModel, arg);
-                return CreateInstantiationExpression(source, classConverter, arg);
+                return CreateInstantiationExpression(source, classConverter, arg, destination);
             }
             else
                 return base.CreateInstantiationExpression(source,destination, arg);

--- a/src/Mapster/Adapters/ReadOnlyInterfaceAdapter.cs
+++ b/src/Mapster/Adapters/ReadOnlyInterfaceAdapter.cs
@@ -38,7 +38,7 @@ namespace Mapster.Adapters
                     return base.CreateInstantiationExpression(source, destination, arg);
                 var ctor = destType.GetConstructors()[0];
                 var classModel = GetConstructorModel(ctor, false);
-                var classConverter = CreateClassConverter(source, classModel, arg);
+                var classConverter = CreateClassConverter(source, classModel, arg,CtorMapping:true);
                 return CreateInstantiationExpression(source, classConverter, arg, destination);
             }
             else

--- a/src/Mapster/Adapters/ReadOnlyInterfaceAdapter.cs
+++ b/src/Mapster/Adapters/ReadOnlyInterfaceAdapter.cs
@@ -38,7 +38,7 @@ namespace Mapster.Adapters
                     return base.CreateInstantiationExpression(source, destination, arg);
                 var ctor = destType.GetConstructors()[0];
                 var classModel = GetConstructorModel(ctor, false);
-                var classConverter = CreateClassConverter(source, classModel, arg,CtorMapping:true);
+                var classConverter = CreateClassConverter(source, classModel, arg, ctorMapping:true);
                 return CreateInstantiationExpression(source, classConverter, arg, destination);
             }
             else

--- a/src/Mapster/Adapters/RecordTypeAdapter.cs
+++ b/src/Mapster/Adapters/RecordTypeAdapter.cs
@@ -194,9 +194,11 @@ namespace Mapster.Adapters
                                 var var2Param = ClassConverterContext.Members.Where(x => x.DestinationMember.Name == member.DestinationMember.Name).FirstOrDefault();
 
                                 Expression destMemberVar2 = var2Param.DestinationMember.GetExpression(var2Param.Destination);
+                                var ParamLambdaVar2 = destMemberVar2;
                                 if(member.DestinationMember.Type.IsRecordType())
-                                    destMemberVar2 = arg.Context.Config.CreateMapInvokeExpressionBody(member.Getter.Type, member.DestinationMember.Type, destMemberVar2);
-                                var blocksVar2 = Expression.Block(SetValueTypeAutoPropertyByReflection(member, destMemberVar2, classModel));
+                                    ParamLambdaVar2 = arg.Context.Config.CreateMapInvokeExpressionBody(member.Getter.Type, member.DestinationMember.Type, destMemberVar2);
+                                
+                                var blocksVar2 = Expression.Block(SetValueTypeAutoPropertyByReflection(member, ParamLambdaVar2, classModel));
                                 var lambdaVar2 = Expression.Lambda(blocksVar2, parameters: new[] { (ParameterExpression)var2Param.Destination, (ParameterExpression)destination });
                                 var adaptVar2 = Expression.Invoke(lambdaVar2, var2Param.Destination, destination);
 

--- a/src/Mapster/Adapters/RecordTypeAdapter.cs
+++ b/src/Mapster/Adapters/RecordTypeAdapter.cs
@@ -1,17 +1,17 @@
-﻿using System;
+﻿using Mapster.Models;
+using Mapster.Utils;
+using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
-using Mapster.Models;
-using Mapster.Utils;
 using static Mapster.IgnoreDictionary;
 
 namespace Mapster.Adapters
 {
     internal class RecordTypeAdapter : ClassAdapter
     {
+        private ClassMapping? ClassConverterContext;
         protected override int Score => -149;
         protected override bool UseTargetValue => false;
 
@@ -20,6 +20,15 @@ namespace Mapster.Adapters
             return arg.DestinationType.IsRecordType();
         }
 
+        protected override bool CanInline(Expression source, Expression? destination, CompileArgument arg)
+        {
+            return false;
+        }
+
+        protected override Expression CreateInlineExpression(Expression source, CompileArgument arg)
+        {
+            return base.CreateInstantiationExpression(source, arg);
+        }
         protected override Expression CreateInstantiationExpression(Expression source, Expression? destination, CompileArgument arg)
         {
             //new TDestination(src.Prop1, src.Prop2)
@@ -37,20 +46,12 @@ namespace Mapster.Adapters
                 var classConverter = CreateClassConverter(source, classModel, arg, ctorMapping: true);
                 installExpr = CreateInstantiationExpression(source, classConverter, arg, destination, restorParamModel);
             }
+
+
             return RecordInlineExpression(source, destination, arg, installExpr); // Activator field when not include in public ctor
         }
-
-        protected override Expression CreateBlockExpression(Expression source, Expression destination, CompileArgument arg)
-        {
-            return Expression.Empty();
-        }
-
-        protected override Expression CreateInlineExpression(Expression source, CompileArgument arg)
-        {
-            return base.CreateInstantiationExpression(source, arg);
-        }
-
-        private Expression? RecordInlineExpression(Expression source, Expression? destination,  CompileArgument arg, Expression installExpr)
+               
+        private Expression? RecordInlineExpression(Expression source, Expression? destination, CompileArgument arg, Expression installExpr)
         {
             //new TDestination {
             //  Prop1 = convert(src.Prop1),
@@ -62,27 +63,43 @@ namespace Mapster.Adapters
             var newInstance = memberInit?.NewExpression ?? (NewExpression)exp;
             var contructorMembers = newInstance.Constructor?.GetParameters().ToList() ?? new();
             var classModel = GetSetterModel(arg);
-            var classConverter = CreateClassConverter(source, classModel, arg, destination:destination,recordRestorMemberModel:classModel);
+            var classConverter = CreateClassConverter(source, classModel, arg, destination: destination, recordRestorMemberModel: classModel);
             var members = classConverter.Members;
+
+            ClassConverterContext = classConverter;
 
             var lines = new List<MemberBinding>();
             if (memberInit != null)
                 lines.AddRange(memberInit.Bindings);
             foreach (var member in members)
             {
-                Expression? value;
 
                 if (!arg.Settings.Resolvers.Any(r => r.DestinationMemberName == member.DestinationMember.Name)
-                    && contructorMembers.Any(x=>string.Equals(x.Name, member.DestinationMember.Name, StringComparison.InvariantCultureIgnoreCase)))
+                    && contructorMembers.Any(x => string.Equals(x.Name, member.DestinationMember.Name, StringComparison.InvariantCultureIgnoreCase)))
                     continue;
 
-                if (member.DestinationMember.SetterModifier == AccessModifier.None && member.UseDestinationValue == false)
+                if (member.DestinationMember.SetterModifier == AccessModifier.None)
                     continue;
 
-                if (member.DestinationMember.SetterModifier == AccessModifier.None && member.UseDestinationValue)
-                    continue; // work in progress
-                else
-                    value = CreateAdaptExpression(member.Getter, member.DestinationMember.Type, arg, member);
+                var adapt = CreateAdaptExpression(member.Getter, member.DestinationMember.Type, arg, member);
+
+                if (arg.MapType == MapType.MapToTarget && arg.Settings.IgnoreNullValues == true && member.Getter.CanBeNull()) // add IgnoreNullValues support
+                {
+                    if (adapt is ConditionalExpression condEx)
+                    {
+                        if (condEx.Test is BinaryExpression { NodeType: ExpressionType.Equal } binEx &&
+                            binEx.Left == member.Getter &&
+                            binEx.Right is ConstantExpression { Value: null })
+                            adapt = condEx.IfFalse;
+                    }
+                    var destinationCompareNull = Expression.Equal(destination, Expression.Constant(null, destination.Type));
+                    var sourceCondition = Expression.NotEqual(member.Getter, Expression.Constant(null, member.Getter.Type));
+                    var destinationCanbeNull = Expression.Condition(destinationCompareNull, member.DestinationMember.Type.CreateDefault(), member.DestinationMember.GetExpression(destination));
+                    adapt = Expression.Condition(sourceCondition, adapt, destinationCanbeNull);
+                }
+
+
+
 
                 //special null property check for projection
                 //if we don't set null to property, EF will create empty object
@@ -93,13 +110,13 @@ namespace Mapster.Adapters
                     && !member.DestinationMember.Type.IsCollection()
                     && member.Getter.Type.GetTypeInfo().GetCustomAttributesData().All(attr => attr.GetAttributeType().Name != "ComplexTypeAttribute"))
                 {
-                    value = member.Getter.NotNullReturn(value);
+                    adapt = member.Getter.NotNullReturn(adapt);
                 }
-                var bind = Expression.Bind((MemberInfo)member.DestinationMember.Info!, value);
+                var bind = Expression.Bind((MemberInfo)member.DestinationMember.Info!, adapt);
                 lines.Add(bind);
             }
 
-            if(arg.MapType == MapType.MapToTarget)
+            if (arg.MapType == MapType.MapToTarget)
                 lines.AddRange(RecordIngnoredWithoutConditonRestore(destination, arg, contructorMembers, classModel));
 
             return Expression.MemberInit(newInstance, lines);
@@ -107,15 +124,15 @@ namespace Mapster.Adapters
 
         private List<MemberBinding> RecordIngnoredWithoutConditonRestore(Expression? destination, CompileArgument arg, List<ParameterInfo> contructorMembers, ClassModel restorPropertyModel)
         {
-           var members = restorPropertyModel.Members
-                            .Where(x=> arg.Settings.Ignore.Any(y=> y.Key == x.Name));
+            var members = restorPropertyModel.Members
+                             .Where(x => arg.Settings.Ignore.Any(y => y.Key == x.Name));
 
             var lines = new List<MemberBinding>();
 
 
             foreach (var member in members)
             {
-                if(destination == null)
+                if (destination == null)
                     continue;
 
                 IgnoreItem ignore;
@@ -123,13 +140,140 @@ namespace Mapster.Adapters
 
                 if (member.SetterModifier == AccessModifier.None ||
                    ignore.Condition != null ||
-                   contructorMembers.Any(x=> string.Equals(x.Name, member.Name, StringComparison.InvariantCultureIgnoreCase)))
+                   contructorMembers.Any(x => string.Equals(x.Name, member.Name, StringComparison.InvariantCultureIgnoreCase)))
                     continue;
 
-               lines.Add(Expression.Bind((MemberInfo)member.Info, Expression.MakeMemberAccess(destination, (MemberInfo)member.Info)));
+                lines.Add(Expression.Bind((MemberInfo)member.Info, Expression.MakeMemberAccess(destination, (MemberInfo)member.Info)));
             }
 
             return lines;
+        }
+
+        protected override Expression CreateBlockExpression(Expression source, Expression destination, CompileArgument arg)
+        {
+            // Mapping property Without setter when UseDestinationValue == true
+
+            var result = destination;
+            var classModel = GetSetterModel(arg);
+            var classConverter = CreateClassConverter(source, classModel, arg, result);
+            var members = classConverter.Members;
+
+            var lines = new List<Expression>();
+
+            foreach (var member in members)
+            {
+                if (member.DestinationMember.SetterModifier == AccessModifier.None && member.UseDestinationValue)
+                {
+
+                    if (member.DestinationMember is PropertyModel && member.DestinationMember.Type.IsValueType 
+                        || member.DestinationMember.Type.IsMapsterPrimitive()
+                        || member.DestinationMember.Type.IsRecordType())
+                    {
+                        
+                        Expression adapt;
+                        if (member.DestinationMember.Type.IsRecordType())
+                            adapt = arg.Context.Config.CreateMapInvokeExpressionBody(member.Getter.Type, member.DestinationMember.Type, member.Getter);
+                        else
+                            adapt = CreateAdaptExpression(member.Getter, member.DestinationMember.Type, arg, member, result);
+
+                        var blocks = Expression.Block(SetValueTypeAutoPropertyByReflection(member, adapt, classModel));
+                        var lambda = Expression.Lambda(blocks, parameters: new[] { (ParameterExpression)source, (ParameterExpression)destination });
+
+                        if (arg.Settings.IgnoreNullValues == true && member.Getter.CanBeNull())
+                        {
+
+                            if (arg.MapType != MapType.MapToTarget)
+                            {
+                                var condition = Expression.NotEqual(member.Getter, Expression.Constant(null, member.Getter.Type));
+                                lines.Add(Expression.IfThen(condition, Expression.Invoke(lambda, source, destination)));
+                                continue;
+                            }
+
+                            if (arg.MapType == MapType.MapToTarget)
+                            {
+                                var var2Param = ClassConverterContext.Members.Where(x => x.DestinationMember.Name == member.DestinationMember.Name).FirstOrDefault();
+
+                                Expression destMemberVar2 = var2Param.DestinationMember.GetExpression(var2Param.Destination);
+                                if(member.DestinationMember.Type.IsRecordType())
+                                    destMemberVar2 = arg.Context.Config.CreateMapInvokeExpressionBody(member.Getter.Type, member.DestinationMember.Type, destMemberVar2);
+                                var blocksVar2 = Expression.Block(SetValueTypeAutoPropertyByReflection(member, destMemberVar2, classModel));
+                                var lambdaVar2 = Expression.Lambda(blocksVar2, parameters: new[] { (ParameterExpression)var2Param.Destination, (ParameterExpression)destination });
+                                var adaptVar2 = Expression.Invoke(lambdaVar2, var2Param.Destination, destination);
+
+
+                                Expression conditionVar2;
+                                if (destMemberVar2.CanBeNull())
+                                {
+                                    var complexcheck = Expression.AndAlso(Expression.NotEqual(var2Param.Destination, Expression.Constant(null, var2Param.Destination.Type)), // if(var2 != null && var2.Prop != null)
+                                    Expression.NotEqual(destMemberVar2, Expression.Constant(null, var2Param.Getter.Type)));
+                                    conditionVar2 = Expression.IfThen(complexcheck, adaptVar2);
+                                }
+                                else
+                                    conditionVar2 = Expression.IfThen(Expression.NotEqual(var2Param.Destination, Expression.Constant(null, var2Param.Destination.Type)), adaptVar2);
+
+                                var condition = Expression.NotEqual(member.Getter, Expression.Constant(null, member.Getter.Type));
+                                lines.Add(Expression.IfThenElse(condition, Expression.Invoke(lambda, source, destination), conditionVar2));
+                                continue;
+                            }
+                        }
+
+                        lines.Add(Expression.Invoke(lambda, source, destination));
+                    }
+                    else
+                    {
+                        var destMember = member.DestinationMember.GetExpression(destination);
+                        var adapt = CreateAdaptExpression(member.Getter, member.DestinationMember.Type, arg, member, destMember);
+
+                        if (arg.Settings.IgnoreNullValues == true && member.Getter.CanBeNull())
+                        {
+                            if (arg.MapType != MapType.MapToTarget)
+                            {
+                                var condition = Expression.NotEqual(member.Getter, Expression.Constant(null, member.Getter.Type));
+                                lines.Add(Expression.IfThen(condition, adapt));
+                                continue;
+                            }
+                            if (arg.MapType == MapType.MapToTarget)
+                            {
+                                var var2Param = ClassConverterContext.Members.Where(x => x.DestinationMember.Name == member.DestinationMember.Name).FirstOrDefault();
+
+                                var destMemberVar2 = var2Param.DestinationMember.GetExpression(var2Param.Destination);
+                                var adaptVar2 = CreateAdaptExpression(destMemberVar2, member.DestinationMember.Type, arg, var2Param, destMember);
+
+                                var complexcheck = Expression.AndAlso(Expression.NotEqual(var2Param.Destination, Expression.Constant(null, var2Param.Destination.Type)), // if(var2 != null && var2.Prop != null)
+                                    Expression.NotEqual(destMemberVar2, Expression.Constant(null, var2Param.Getter.Type)));
+                                var conditionVar2 = Expression.IfThen(complexcheck, adaptVar2);
+
+                                var condition = Expression.NotEqual(member.Getter, Expression.Constant(null, member.Getter.Type));
+                                lines.Add(Expression.IfThenElse(condition, adapt, conditionVar2));
+                                continue;
+                            }
+
+
+                        }
+
+                        lines.Add(adapt);
+                    }
+
+                }
+            }
+
+            return lines.Count > 0 ? (Expression)Expression.Block(lines) : Expression.Empty();
+        }
+
+        protected static Expression SetValueTypeAutoPropertyByReflection(MemberMapping member, Expression adapt, ClassModel checkmodel)
+        {
+            var modDesinationMemeberName = $"<{member.DestinationMember.Name}>k__BackingField";
+            if (checkmodel.Members.Any(x => x.Name == modDesinationMemeberName) == false) // Property is not autoproperty
+                return Expression.Empty();
+            var typeofExpression = Expression.Constant(member.Destination!.Type);
+            var getPropertyMethod = typeof(Type).GetMethod("GetField", new[] { typeof(string), typeof(BindingFlags) })!;
+            var getPropertyExpression = Expression.Call(typeofExpression, getPropertyMethod,
+                Expression.Constant(modDesinationMemeberName), Expression.Constant(BindingFlags.Instance | BindingFlags.NonPublic));
+            var setValueMethod =
+                typeof(FieldInfo).GetMethod("SetValue", new[] { typeof(object), typeof(object) })!;
+            var memberAsObject = adapt.To(typeof(object));
+            return Expression.Call(getPropertyExpression, setValueMethod,
+                new[] { member.Destination, memberAsObject });
         }
     }
 

--- a/src/Mapster/Adapters/RecordTypeAdapter.cs
+++ b/src/Mapster/Adapters/RecordTypeAdapter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -69,17 +70,19 @@ namespace Mapster.Adapters
                 lines.AddRange(memberInit.Bindings);
             foreach (var member in members)
             {
-                if (member.UseDestinationValue)
-                    return null;
+                Expression? value;
 
                 if (!arg.Settings.Resolvers.Any(r => r.DestinationMemberName == member.DestinationMember.Name)
                     && contructorMembers.Any(x=>string.Equals(x.Name, member.DestinationMember.Name, StringComparison.InvariantCultureIgnoreCase)))
                     continue;
 
-                if (member.DestinationMember.SetterModifier == AccessModifier.None)
+                if (member.DestinationMember.SetterModifier == AccessModifier.None && member.UseDestinationValue == false)
                     continue;
 
-                var value = CreateAdaptExpression(member.Getter, member.DestinationMember.Type, arg, member);
+                if (member.DestinationMember.SetterModifier == AccessModifier.None && member.UseDestinationValue)
+                    continue; // work in progress
+                else
+                    value = CreateAdaptExpression(member.Getter, member.DestinationMember.Type, arg, member);
 
                 //special null property check for projection
                 //if we don't set null to property, EF will create empty object

--- a/src/Mapster/Adapters/RecordTypeAdapter.cs
+++ b/src/Mapster/Adapters/RecordTypeAdapter.cs
@@ -31,7 +31,7 @@ namespace Mapster.Adapters
             var ctor = destType.GetConstructors()
                     .OrderByDescending(it => it.GetParameters().Length).ToArray().FirstOrDefault(); // Will be used public constructor with the maximum number of parameters 
             var classModel = GetConstructorModel(ctor, false);
-            var classConverter = CreateClassConverter(source, classModel, arg, CtorMapping:true);
+            var classConverter = CreateClassConverter(source, classModel, arg, ctorMapping:true);
             var installExpr = CreateInstantiationExpression(source, classConverter, arg, destination);
             return RecordInlineExpression(source, arg, installExpr); // Activator field when not include in public ctor
         }

--- a/src/Mapster/Adapters/RecordTypeAdapter.cs
+++ b/src/Mapster/Adapters/RecordTypeAdapter.cs
@@ -31,8 +31,8 @@ namespace Mapster.Adapters
             var ctor = destType.GetConstructors()
                     .OrderByDescending(it => it.GetParameters().Length).ToArray().FirstOrDefault(); // Will be used public constructor with the maximum number of parameters 
             var classModel = GetConstructorModel(ctor, false);
-            var classConverter = CreateClassConverter(source, classModel, arg);
-            var installExpr = CreateInstantiationExpression(source, classConverter, arg);
+            var classConverter = CreateClassConverter(source, classModel, arg, CtorMapping:true);
+            var installExpr = CreateInstantiationExpression(source, classConverter, arg, destination);
             return RecordInlineExpression(source, arg, installExpr); // Activator field when not include in public ctor
         }
 


### PR DESCRIPTION
Fix Issue #456 #707 #723

#456 When explicitly set to ignore():

Instance of a class can be created with default values ​​for parameters.
Explicitly set to ignore() not mark param as not matched when config RequireDestinationMemberSource = true,

#707  #723 RecordTypes and Generated Type to Interface received support Ignore() from Ctor parameters

Fix MapToTarget behavior for RecordTypes (Include using Ignore() )

before  from 
```
record TestRecord()
{
    public int X { set; get; }
}
record TestRecordY() 
{
    public int X { set; get; }
    public int Y { set; get; }
}

var source = new TestRecord() { X= 200};
var dest = new TestRecordY() {X = 100, Y= 500}

```

```
var adapt = source.Adapt(dest)  // always adapt == { X=200, Y=0}
```

after 

```
var adapt = source.Adapt(dest)  // adapt == { X=200, Y=500}  Correct MapTotarget
```

equal behavior when modified using with 

```
var adapt = dest with {X=source.X};
```
add Support from RecordType

- IgnoreNullValues()
- UseDestinationValue
- UseDestination value from Primitive type (and RecordType) AutoProperty 