### PR TITLE
Allow mapping to a dictionary with a key containing periods

### DIFF
--- a/src/Mapster.Tests/WhenMappingWithDictionary.cs
+++ b/src/Mapster.Tests/WhenMappingWithDictionary.cs
@@ -37,7 +37,6 @@ namespace Mapster.Tests
             dict["Name"].ShouldBe(poco.Name);
         }
 
-
         [TestMethod]
         public void Object_To_Dictionary_Map()
         {
@@ -54,6 +53,25 @@ namespace Mapster.Tests
 
             dict.Count.ShouldBe(2);
             dict["Code"].ShouldBe(poco.Id);
+            dict["Name"].ShouldBe(poco.Name);
+        }
+
+        [TestMethod]
+        public void Object_To_Dictionary_Map_With_Periods()
+        {
+            var poco = new SimplePoco
+            {
+                Id = Guid.NewGuid(),
+                Name = "test",
+            };
+
+            var config = new TypeAdapterConfig();
+            config.NewConfig<SimplePoco, Dictionary<string, object>>()
+                .Map("Key.With.Periods", c => c.Id);
+            var dict = poco.Adapt<Dictionary<string, object>>(config);
+
+            dict.Count.ShouldBe(2);
+            dict["Key.With.Periods"].ShouldBe(poco.Id);
             dict["Name"].ShouldBe(poco.Name);
         }
 

--- a/src/Mapster.Tests/WhenMappingWithDictionary.cs
+++ b/src/Mapster.Tests/WhenMappingWithDictionary.cs
@@ -173,6 +173,23 @@ namespace Mapster.Tests
         }
 
         [TestMethod]
+        public void Dictionary_To_Object_Map_With_Periods()
+        {
+            var dict = new Dictionary<string, object>
+            {
+                ["Key.With.Periods"] = Guid.NewGuid(),
+                ["Foo"] = "test",
+            };
+
+            TypeAdapterConfig<Dictionary<string, object>, SimplePoco>.NewConfig()
+                .Map(c => c.Id, "Key.With.Periods");
+
+            var poco = TypeAdapter.Adapt<SimplePoco>(dict);
+            poco.Id.ShouldBe(dict["Key.With.Periods"]);
+            poco.Name.ShouldBeNull();
+        }
+
+        [TestMethod]
         public void Dictionary_To_Object_CamelCase()
         {
             TypeAdapterConfig.GlobalSettings.Default.NameMatchingStrategy(NameMatchingStrategy.FromCamelCase);

--- a/src/Mapster/Adapters/DictionaryAdapter.cs
+++ b/src/Mapster/Adapters/DictionaryAdapter.cs
@@ -219,7 +219,7 @@ namespace Mapster.Adapters
         protected override ClassModel GetSetterModel(CompileArgument arg)
         {
             //get member name from map
-            var destNames = arg.GetDestinationNames().AsEnumerable();
+            var destNames = arg.GetDestinationNames(false).AsEnumerable();
 
             //get member name from properties
             if (arg.SourceType.GetDictionaryType() == null)

--- a/src/Mapster/Compile/CompileArgument.cs
+++ b/src/Mapster/Compile/CompileArgument.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
-using Mapster.Utils;
 
 namespace Mapster
 {
@@ -20,16 +19,18 @@ namespace Mapster
         internal HashSet<string> GetSourceNames()
         {
             return _srcNames ??= (from it in Settings.Resolvers
-                where it.SourceMemberName != null
-                select it.SourceMemberName!.Split('.').First()).ToHashSet();
+                                  where it.SourceMemberName != null
+                                  select it.SourceMemberName!.Split('.').First()).ToHashSet();
         }
 
         private HashSet<string>? _destNames;
-        internal HashSet<string> GetDestinationNames()
+        internal HashSet<string> GetDestinationNames(bool split = true)
         {
             return _destNames ??= (from it in Settings.Resolvers
-                where it.DestinationMemberName != null
-                select it.DestinationMemberName.Split('.').First()).ToHashSet();
+                                   where it.DestinationMemberName != null
+                                   select split
+                                       ? it.DestinationMemberName.Split('.').First()
+                                       : it.DestinationMemberName).ToHashSet();
         }
 
         private bool _fetchConstructUsing;


### PR DESCRIPTION
Very basic change to allow for mapping to a dictionary, where the key contains a period.
Without this change, `config.NewConfig<SimplePoco, Dictionary<string, object>>().Map("Key.With.Periods", c => c.Id);` would map to key `"Key"` instead of `"Key.With.Periods"`.

Simply never splitting in the method `CompileArgument.GetDestinationNames` does not make any test fail. However, the method is also referenced from `ReflectionUtils.ShouldMapMember`. It might be that a failing scenario is simply not covered in tests, which is why the option is provided.