### PR TITLE
Improve nullability annotations on the Adapt extension method

### DIFF
--- a/src/Mapster/TypeAdapter.cs
+++ b/src/Mapster/TypeAdapter.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
 namespace Mapster
@@ -21,7 +22,8 @@ namespace Mapster
         /// <typeparam name="TDestination">Destination type.</typeparam>
         /// <param name="source">Source object to adapt.</param>
         /// <returns>Adapted destination type.</returns>
-        public static TDestination Adapt<TDestination>(this object? source)
+        [return: NotNullIfNotNull(nameof(source))]
+        public static TDestination? Adapt<TDestination>(this object? source)
         {
             return Adapt<TDestination>(source, TypeAdapterConfig.GlobalSettings);
         }
@@ -33,14 +35,15 @@ namespace Mapster
         /// <param name="source">Source object to adapt.</param>
         /// <param name="config">Configuration</param>
         /// <returns>Adapted destination type.</returns>
-        public static TDestination Adapt<TDestination>(this object? source, TypeAdapterConfig config)
+        [return: NotNullIfNotNull(nameof(source))]
+        public static TDestination? Adapt<TDestination>(this object? source, TypeAdapterConfig config)
         {
             // ReSharper disable once ConditionIsAlwaysTrueOrFalse
             if (source == null)
-                return default!;
+                return default;
             var type = source.GetType();
             var fn = config.GetDynamicMapFunction<TDestination>(type);
-            return fn(source);
+            return fn(source)!;
         }
 
         /// <summary>


### PR DESCRIPTION
This PR introduces nullability annotations. A warning will now be triggered when attempting to map a nullable input to a non-nullable output, for example: `ProductDTO dto = ((Product?)null).Adapt<ProductDTO>()`;