### PR TITLE
Add enhanced Mapster dependency injection system with fluent configuration API 

### DIFF
--- a/src/Mapster.DependencyInjection.Tests/EnhancedDITests.cs
+++ b/src/Mapster.DependencyInjection.Tests/EnhancedDITests.cs
@@ -1,0 +1,266 @@
+﻿using MapsterMapper;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Shouldly;
+using System.Reflection;
+
+namespace Mapster.DependencyInjection.Tests
+{
+    [TestClass]
+    public class EnhancedDITests
+    {
+        [TestMethod]
+        public void AddMapster_WithOptions_ShouldRegisterServiceMapper()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+
+            // Act
+            services.AddMapster(options =>
+            {
+                options.UseServiceMapper = true;
+                options.ConfigureAction = config =>
+                {
+                    config.NewConfig<Source, Destination>()
+                        .Map(dest => dest.FullName, src => $"{src.FirstName} {src.LastName}");
+                };
+            });
+
+            var serviceProvider = services.BuildServiceProvider();
+            var mapper = serviceProvider.GetRequiredService<IMapper>();
+
+            // Assert
+            mapper.ShouldNotBeNull();
+            mapper.ShouldBeOfType<ServiceMapper>();
+
+            var source = new Source { FirstName = "John", LastName = "Doe" };
+            var destination = mapper.Map<Source, Destination>(source);
+            destination.FullName.ShouldBe("John Doe");
+        }
+
+        [TestMethod]
+        public void AddMapster_WithConfigureAction_ShouldApplyConfiguration()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+
+            // Act
+            services.AddMapster(config =>
+            {
+                config.NewConfig<Source, Destination>()
+                    .Map(dest => dest.FullName, src => $"{src.FirstName} {src.LastName}");
+            });
+
+            var serviceProvider = services.BuildServiceProvider();
+            var mapper = serviceProvider.GetRequiredService<IMapper>();
+
+            // Assert
+            var source = new Source { FirstName = "Jane", LastName = "Smith" };
+            var destination = mapper.Map<Source, Destination>(source);
+            destination.FullName.ShouldBe("Jane Smith");
+        }
+
+        [TestMethod]
+        public void AddMapsterWithConfig_ShouldUseExistingConfig()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            var config = new TypeAdapterConfig();
+            config.NewConfig<Source, Destination>()
+                .Map(dest => dest.FullName, src => $"{src.FirstName} {src.LastName}");
+
+            // Act
+            services.AddMapsterWithConfig(config);
+
+            var serviceProvider = services.BuildServiceProvider();
+            var mapper = serviceProvider.GetRequiredService<IMapper>();
+
+            // Assert
+            var source = new Source { FirstName = "Bob", LastName = "Johnson" };
+            var destination = mapper.Map<Source, Destination>(source);
+            destination.FullName.ShouldBe("Bob Johnson");
+        }
+
+        [TestMethod]
+        public void AddMapsterFrozen_ShouldFreezeConfiguration()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+
+            // Act
+            services.AddMapsterFrozen(config =>
+            {
+                config.NewConfig<Source, Destination>()
+                    .Map(dest => dest.FullName, src => $"{src.FirstName} {src.LastName}");
+            });
+
+            var serviceProvider = services.BuildServiceProvider();
+            var mapper = serviceProvider.GetRequiredService<IMapper>();
+
+            // Assert
+            var source = new Source { FirstName = "Alice", LastName = "Williams" };
+            var destination = mapper.Map<Source, Destination>(source);
+            destination.FullName.ShouldBe("Alice Williams");
+        }
+
+        [TestMethod]
+        public void AddMapsterModule_ShouldRegisterModule()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+
+            // Act
+            services.AddMapsterModule<TestMapsterModule>();
+
+            var serviceProvider = services.BuildServiceProvider();
+            var mapper = serviceProvider.GetRequiredService<IMapper>();
+
+            // Assert
+            var source = new Source { FirstName = "Module", LastName = "Test" };
+            var destination = mapper.Map<Source, Destination>(source);
+            destination.FullName.ShouldBe("Module Test");
+        }
+
+        [TestMethod]
+        public void ScanMapster_ShouldScanAssemblies()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+
+            // Act
+            services.ScanMapster(Assembly.GetExecutingAssembly());
+
+            var serviceProvider = services.BuildServiceProvider();
+            var mapper = serviceProvider.GetRequiredService<IMapper>();
+
+            // Assert
+            mapper.ShouldNotBeNull();
+            mapper.ShouldBeOfType<ServiceMapper>();
+        }
+
+        [TestMethod]
+        public void AddMapster_BackwardCompatibility_ShouldStillWork()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            var config = new TypeAdapterConfig();
+            config.NewConfig<Source, Destination>()
+                .Map(dest => dest.FullName, src => $"{src.FirstName} {src.LastName}");
+            services.AddSingleton(config);
+
+            // Act
+            services.AddMapster();
+
+            var serviceProvider = services.BuildServiceProvider();
+            var mapper = serviceProvider.GetRequiredService<IMapper>();
+
+            // Assert
+            mapper.ShouldNotBeNull();
+            // Note: Without config parameter, it uses default Mapper, not ServiceMapper
+            mapper.ShouldBeOfType<Mapper>();
+        }
+
+        [TestMethod]
+        public void AddMapster_WithBuildActions_ShouldExecuteActions()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            var beforeCompileCalled = false;
+            var afterCompileCalled = false;
+
+            // Act
+            services.AddMapster(
+                config =>
+                {
+                    config.NewConfig<Source, Destination>()
+                        .Map(dest => dest.FullName, src => $"{src.FirstName} {src.LastName}");
+                },
+                actions =>
+                {
+                    actions.OnBeforeCompile = _ => beforeCompileCalled = true;
+                    actions.OnAfterCompile = _ => afterCompileCalled = true;
+                });
+
+            var serviceProvider = services.BuildServiceProvider();
+            var mapper = serviceProvider.GetRequiredService<IMapper>();
+
+            // Assert
+            beforeCompileCalled.ShouldBeTrue();
+            afterCompileCalled.ShouldBeTrue();
+
+            var source = new Source { FirstName = "Test", LastName = "User" };
+            var destination = mapper.Map<Source, Destination>(source);
+            destination.FullName.ShouldBe("Test User");
+        }
+
+        [TestMethod]
+        public void AddMapster_WithPrecompile_ShouldPrecompileTypePairs()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+
+            // Act
+            services.AddMapster(options =>
+            {
+                options.ConfigureAction = config =>
+                {
+                    config.NewConfig<Source, Destination>()
+                        .Map(dest => dest.FullName, src => $"{src.FirstName} {src.LastName}");
+                };
+                options.TypePairsToPrecompile.Add((typeof(Source), typeof(Destination)));
+            });
+
+            var serviceProvider = services.BuildServiceProvider();
+            var mapper = serviceProvider.GetRequiredService<IMapper>();
+
+            // Assert - Should work without errors
+            var source = new Source { FirstName = "Pre", LastName = "Compiled" };
+            var destination = mapper.Map<Source, Destination>(source);
+            destination.FullName.ShouldBe("Pre Compiled");
+        }
+    }
+
+    // Test classes
+    public class Source
+    {
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+    }
+
+    public class Destination
+    {
+        public string FullName { get; set; }
+    }
+
+    // Test module
+    public class TestMapsterModule : IMapsterModule
+    {
+        public void Register(TypeAdapterConfig config)
+        {
+            config.NewConfig<Source, Destination>()
+                .Map(dest => dest.FullName, src => $"{src.FirstName} {src.LastName}");
+        }
+    }
+
+    // Test register class
+    public class TestRegister : IRegister
+    {
+        public void Register(TypeAdapterConfig config)
+        {
+            config.NewConfig<Source, Destination>()
+                .Map(dest => dest.FullName, src => $"{src.FirstName} {src.LastName}");
+        }
+    }
+
+    // Test IMapFrom implementation
+    public class DestinationWithMapFrom : IMapFrom<Source>
+    {
+        public string FullName { get; set; }
+
+        public void ConfigureMapping(TypeAdapterConfig config)
+        {
+            config.NewConfig<Source, DestinationWithMapFrom>()
+                .Map(dest => dest.FullName, src => $"{src.FirstName} {src.LastName}");
+        }
+    }
+}

--- a/src/Mapster.DependencyInjection/DefaultMapContextFactory.cs
+++ b/src/Mapster.DependencyInjection/DefaultMapContextFactory.cs
@@ -1,0 +1,18 @@
+﻿using MapsterMapper;
+using System;
+
+namespace Mapster
+{
+    /// <summary>
+    /// Default implementation of IMapContextFactory.
+    /// </summary>
+    public class DefaultMapContextFactory : IMapContextFactory
+    {
+        public IDisposable CreateScope(IServiceProvider serviceProvider)
+        {
+            var scope = new MapContextScope();
+            scope.Context.Parameters[ServiceMapper.DI_KEY] = serviceProvider;
+            return scope;
+        }
+    }
+}

--- a/src/Mapster.DependencyInjection/IMapContextFactory.cs
+++ b/src/Mapster.DependencyInjection/IMapContextFactory.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace Mapster
+{
+    /// <summary>
+    /// Factory for creating MapContext scopes.
+    /// </summary>
+    public interface IMapContextFactory
+    {
+        /// <summary>
+        /// Creates a new MapContext scope with the service provider.
+        /// </summary>
+        /// <param name="serviceProvider">The service provider to associate with the context.</param>
+        /// <returns>A disposable MapContext scope.</returns>
+        IDisposable CreateScope(IServiceProvider serviceProvider);
+    }
+}

--- a/src/Mapster.DependencyInjection/IMapsterModule.cs
+++ b/src/Mapster.DependencyInjection/IMapsterModule.cs
@@ -1,0 +1,15 @@
+﻿namespace Mapster
+{
+    /// <summary>
+    /// Interface for Mapster extension modules.
+    /// Implement this to create reusable configuration modules.
+    /// </summary>
+    public interface IMapsterModule
+    {
+        /// <summary>
+        /// Register mappings and configuration in the provided config.
+        /// </summary>
+        /// <param name="config">The TypeAdapterConfig to configure.</param>
+        void Register(TypeAdapterConfig config);
+    }
+}

--- a/src/Mapster.DependencyInjection/MapsterBuildActions.cs
+++ b/src/Mapster.DependencyInjection/MapsterBuildActions.cs
@@ -1,0 +1,35 @@
+﻿using System;
+
+namespace Mapster
+{
+    /// <summary>
+    /// Actions to be executed during Mapster build phase.
+    /// </summary>
+    public class MapsterBuildActions
+    {
+        /// <summary>
+        /// Gets or sets the action to execute before compilation.
+        /// </summary>
+        public Action<TypeAdapterConfig> OnBeforeCompile { get; set; }
+
+        /// <summary>
+        /// Gets or sets the action to execute after compilation.
+        /// </summary>
+        public Action<TypeAdapterConfig> OnAfterCompile { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether to scan assemblies for IRegister and IMapFrom implementations.
+        /// </summary>
+        public bool ScanAssemblies { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether to precompile type pairs.
+        /// </summary>
+        public bool PrecompileTypePairs { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether to freeze the configuration.
+        /// </summary>
+        public bool Freeze { get; set; }
+    }
+}

--- a/src/Mapster.DependencyInjection/MapsterBuilder.cs
+++ b/src/Mapster.DependencyInjection/MapsterBuilder.cs
@@ -1,0 +1,132 @@
+﻿using Mapster.Utils;
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Collections.Generic; // added for error collection
+
+namespace Mapster
+{
+    /// <summary>
+    /// Internal builder for executing Mapster build phase.
+    /// </summary>
+    internal class MapsterBuilder
+    {
+        private readonly TypeAdapterConfig _config;
+        private readonly MapsterOptions _options;
+
+        public MapsterBuilder(TypeAdapterConfig config, MapsterOptions options)
+        {
+            _config = config ?? throw new ArgumentNullException(nameof(config));
+            _options = options ?? throw new ArgumentNullException(nameof(options));
+        }
+
+        public void Build(MapsterBuildActions? buildActions = null)
+        {
+            buildActions ??= new MapsterBuildActions();
+
+            // Register modules
+            foreach (var module in _options.Modules)
+            {
+                module.Register(_config);
+            }
+
+            // Scan assemblies if requested
+            if (buildActions.ScanAssemblies && _options.AssembliesToScan.Any())
+            {
+                ScanAssemblies();
+            }
+
+            // Invoke before compile hook
+            buildActions.OnBeforeCompile?.Invoke(_config);
+
+            // Precompile type pairs if requested
+            if (buildActions.PrecompileTypePairs && _options.TypePairsToPrecompile.Any())
+            {
+                PrecompileTypePairs();
+            }
+
+            // Invoke after compile hook
+            buildActions.OnAfterCompile?.Invoke(_config);
+
+            // Freeze configuration if requested
+            if (buildActions.Freeze || _options.FreezeConfiguration)
+            {
+                FreezeConfiguration();
+            }
+        }
+
+        private void ScanAssemblies()
+        {
+            // Scan for IRegister implementations (existing functionality)
+            var assemblies = _options.AssembliesToScan.ToArray();
+            _config.Scan(assemblies);
+
+            // Scan for IMapFrom<T> implementations
+            ScanForIMapFrom(assemblies);
+        }
+
+        private void ScanForIMapFrom(Assembly[] assemblies)
+        {
+            var mapFromInterface = typeof(IMapFrom<>);
+
+            foreach (var assembly in assemblies)
+            {
+                var types = assembly.GetLoadableTypes()
+                    .Where(t => t.GetTypeInfo().IsClass && !t.GetTypeInfo().IsAbstract);
+
+                foreach (var type in types)
+                {
+                    var interfaces = type.GetTypeInfo().GetInterfaces()
+                        .Where(i => i.GetTypeInfo().IsGenericType &&
+                                   i.GetGenericTypeDefinition() == mapFromInterface);
+
+                    foreach (var @interface in interfaces)
+                    {
+                        var instance = Activator.CreateInstance(type);
+                        var method = @interface.GetMethod("ConfigureMapping");
+
+                        if (method != null)
+                        {
+                            // Call the ConfigureMapping method
+                            method.Invoke(instance, new object[] { _config });
+                        }
+                    }
+                }
+            }
+        }
+
+        private void PrecompileTypePairs()
+        {
+            List<Exception>? errors = null;
+            foreach (var (source, destination) in _options.TypePairsToPrecompile)
+            {
+                try
+                {
+                    // Force compilation by getting the map function using reflection
+                    var method = typeof(TypeAdapterConfig).GetMethod("GetMapFunction",
+                        BindingFlags.Instance | BindingFlags.Public)
+                        ?.MakeGenericMethod(source, destination);
+                    method?.Invoke(_config, Array.Empty<object>());
+                }
+                catch (Exception ex)
+                {
+                    // Collect errors instead of silently ignoring them
+                    errors ??= new List<Exception>();
+                    errors.Add(new InvalidOperationException($"Failed to precompile mapping from {source} to {destination}.", ex));
+                }
+            }
+
+            if (errors is { Count: > 0 })
+            {
+                throw new AggregateException("One or more type pairs failed to precompile.", errors);
+            }
+        }
+
+        private void FreezeConfiguration()
+        {
+            // Set the compiler to use compiled delegates
+            // This improves performance by avoiding runtime compilation
+            _config.Compiler = lambda => lambda.Compile();
+        }
+    }
+}

--- a/src/Mapster.DependencyInjection/MapsterOptions.cs
+++ b/src/Mapster.DependencyInjection/MapsterOptions.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Mapster
+{
+    /// <summary>
+    /// Options for configuring Mapster dependency injection.
+    /// </summary>
+    public class MapsterOptions
+    {
+        /// <summary>
+        /// Gets or sets the assemblies to scan for IRegister implementations and IMapFrom patterns.
+        /// </summary>
+        public ICollection<Assembly> AssembliesToScan { get; set; } = new List<Assembly>();
+
+        /// <summary>
+        /// Gets or sets the type pairs to precompile.
+        /// </summary>
+        public ICollection<(Type Source, Type Destination)> TypePairsToPrecompile { get; set; } = new List<(Type, Type)>();
+
+        /// <summary>
+        /// Gets or sets whether to use ServiceMapper (with DI support) instead of regular Mapper.
+        /// Default is true.
+        /// </summary>
+        public bool UseServiceMapper { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets whether to freeze the configuration after build.
+        /// Frozen configs provide better performance but cannot be modified.
+        /// </summary>
+        public bool FreezeConfiguration { get; set; }
+
+        /// <summary>
+        /// Gets or sets the configuration action to apply to TypeAdapterConfig.
+        /// </summary>
+        public Action<TypeAdapterConfig> ConfigureAction { get; set; }
+
+        /// <summary>
+        /// Gets or sets the modules to register.
+        /// </summary>
+        public ICollection<IMapsterModule> Modules { get; set; } = new List<IMapsterModule>();
+    }
+}

--- a/src/Mapster.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Mapster.DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,13 +1,181 @@
 ﻿using MapsterMapper;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using System;
+using System.Reflection;
 
 namespace Mapster
 {
     public static class ServiceCollectionExtensions
     {
-        public static void AddMapster(this IServiceCollection serviceCollection)
+        /// <summary>
+        /// Adds Mapster with default configuration (uses regular Mapper, no DI support).
+        /// Preserved for backward compatibility.
+        /// </summary>
+        public static IServiceCollection AddMapster(this IServiceCollection serviceCollection)
         {
-            serviceCollection.AddTransient<IMapper, Mapper>();
+            serviceCollection.TryAddTransient<IMapper, Mapper>();
+            return serviceCollection;
+        }
+
+        /// <summary>
+        /// Adds Mapster with fluent configuration options.
+        /// </summary>
+        /// <param name="serviceCollection">The service collection.</param>
+        /// <param name="configureOptions">Action to configure MapsterOptions.</param>
+        /// <returns>The service collection for chaining.</returns>
+        public static IServiceCollection AddMapster(
+            this IServiceCollection serviceCollection,
+            Action<MapsterOptions> configureOptions)
+        {
+            var options = new MapsterOptions();
+            configureOptions?.Invoke(options);
+
+            // Create and configure TypeAdapterConfig
+            var config = new TypeAdapterConfig();
+            options.ConfigureAction?.Invoke(config);
+
+            // Build the configuration
+            var builder = new MapsterBuilder(config, options);
+            var buildActions = new MapsterBuildActions
+            {
+                ScanAssemblies = options.AssembliesToScan.Count > 0,
+                PrecompileTypePairs = options.TypePairsToPrecompile.Count > 0,
+                Freeze = options.FreezeConfiguration
+            };
+            builder.Build(buildActions);
+
+            // Register the configuration
+            serviceCollection.TryAddSingleton(config);
+
+            // Register the appropriate mapper
+            if (options.UseServiceMapper)
+            {
+                serviceCollection.TryAddTransient<IMapper, ServiceMapper>();
+            }
+            else
+            {
+                serviceCollection.TryAddTransient<IMapper, Mapper>();
+            }
+
+            // Register the MapContext factory
+            serviceCollection.TryAddSingleton<IMapContextFactory, DefaultMapContextFactory>();
+
+            return serviceCollection;
+        }
+
+        /// <summary>
+        /// Adds Mapster with direct configuration and build actions.
+        /// </summary>
+        /// <param name="serviceCollection">The service collection.</param>
+        /// <param name="configure">Action to configure TypeAdapterConfig.</param>
+        /// <param name="buildActions">Optional build actions to execute.</param>
+        /// <returns>The service collection for chaining.</returns>
+        public static IServiceCollection AddMapster(
+            this IServiceCollection serviceCollection,
+            Action<TypeAdapterConfig> configure,
+            Action<MapsterBuildActions>? buildActions = null)
+        {
+            var config = new TypeAdapterConfig();
+            configure?.Invoke(config);
+
+            var actions = new MapsterBuildActions();
+            buildActions?.Invoke(actions);
+
+            var options = new MapsterOptions { UseServiceMapper = true };
+            var builder = new MapsterBuilder(config, options);
+            builder.Build(actions);
+
+            serviceCollection.TryAddSingleton(config);
+            serviceCollection.TryAddTransient<IMapper, ServiceMapper>();
+            serviceCollection.TryAddSingleton<IMapContextFactory, DefaultMapContextFactory>();
+
+            return serviceCollection;
+        }
+
+        /// <summary>
+        /// Adds Mapster with an existing TypeAdapterConfig.
+        /// </summary>
+        /// <param name="serviceCollection">The service collection.</param>
+        /// <param name="existingConfig">The existing TypeAdapterConfig to use.</param>
+        /// <param name="buildActions">Optional build actions to execute.</param>
+        /// <returns>The service collection for chaining.</returns>
+        public static IServiceCollection AddMapsterWithConfig(
+            this IServiceCollection serviceCollection,
+            TypeAdapterConfig existingConfig,
+            Action<MapsterBuildActions>? buildActions = null)
+        {
+            if (existingConfig == null)
+                throw new ArgumentNullException(nameof(existingConfig));
+
+            var actions = new MapsterBuildActions();
+            buildActions?.Invoke(actions);
+
+            var options = new MapsterOptions { UseServiceMapper = true };
+            var builder = new MapsterBuilder(existingConfig, options);
+            builder.Build(actions);
+
+            serviceCollection.TryAddSingleton(existingConfig);
+            serviceCollection.TryAddTransient<IMapper, ServiceMapper>();
+            serviceCollection.TryAddSingleton<IMapContextFactory, DefaultMapContextFactory>();
+
+            return serviceCollection;
+        }
+
+        /// <summary>
+        /// Adds Mapster with frozen configuration for high-throughput scenarios.
+        /// </summary>
+        /// <param name="serviceCollection">The service collection.</param>
+        /// <param name="configure">Action to configure TypeAdapterConfig.</param>
+        /// <returns>The service collection for chaining.</returns>
+        public static IServiceCollection AddMapsterFrozen(
+            this IServiceCollection serviceCollection,
+            Action<TypeAdapterConfig> configure)
+        {
+            return serviceCollection.AddMapster(configure, actions =>
+            {
+                actions.Freeze = true;
+            });
+        }
+
+        /// <summary>
+        /// Adds a Mapster module to the configuration.
+        /// </summary>
+        /// <typeparam name="TModule">The module type to register.</typeparam>
+        /// <param name="serviceCollection">The service collection.</param>
+        /// <returns>The service collection for chaining.</returns>
+        public static IServiceCollection AddMapsterModule<TModule>(this IServiceCollection serviceCollection)
+            where TModule : IMapsterModule, new()
+        {
+            var module = new TModule();
+            var config = new TypeAdapterConfig();
+            module.Register(config);
+
+            serviceCollection.TryAddSingleton(config);
+            serviceCollection.TryAddTransient<IMapper, ServiceMapper>();
+            serviceCollection.TryAddSingleton<IMapContextFactory, DefaultMapContextFactory>();
+
+            return serviceCollection;
+        }
+
+        /// <summary>
+        /// Scans assemblies for IRegister and IMapFrom implementations.
+        /// </summary>
+        /// <param name="serviceCollection">The service collection.</param>
+        /// <param name="assemblies">Assemblies to scan.</param>
+        /// <returns>The service collection for chaining.</returns>
+        public static IServiceCollection ScanMapster(
+            this IServiceCollection serviceCollection,
+            params Assembly[] assemblies)
+        {
+            return serviceCollection.AddMapster(options =>
+            {
+                foreach (var assembly in assemblies)
+                {
+                    options.AssembliesToScan.Add(assembly);
+                }
+                options.UseServiceMapper = true;
+            });
         }
     }
 }

--- a/src/Sample.AspNetCore/Mappings/UserMappingConfig.cs
+++ b/src/Sample.AspNetCore/Mappings/UserMappingConfig.cs
@@ -1,0 +1,20 @@
+﻿using Mapster;
+using Sample.AspNetCore.Models;
+using System;
+
+namespace Sample.AspNetCore.Mappings
+{
+    /// <summary>
+    /// Example of using IRegister pattern for mapping configuration.
+    /// This will be automatically discovered when using assembly scanning.
+    /// </summary>
+    public class UserMappingConfig : IRegister
+    {
+        public void Register(TypeAdapterConfig config)
+        {
+            config.NewConfig<User, UserDto>()
+                .Map(dest => dest.FullName, src => $"{src.FirstName} {src.LastName}")
+                .Map(dest => dest.Age, src => DateTime.Now.Year - src.BirthYear);
+        }
+    }
+}

--- a/src/Sample.AspNetCore/Models/User.cs
+++ b/src/Sample.AspNetCore/Models/User.cs
@@ -1,0 +1,19 @@
+﻿namespace Sample.AspNetCore.Models
+{
+    public class User
+    {
+        public int Id { get; set; }
+        public string FirstName { get; set; } = string.Empty;
+        public string LastName { get; set; } = string.Empty;
+        public string Email { get; set; } = string.Empty;
+        public int BirthYear { get; set; }
+    }
+
+    public class UserDto
+    {
+        public int Id { get; set; }
+        public string FullName { get; set; } = string.Empty;
+        public string Email { get; set; } = string.Empty;
+        public int Age { get; set; }
+    }
+}

--- a/src/Sample.AspNetCore/StartupEnhanced.cs
+++ b/src/Sample.AspNetCore/StartupEnhanced.cs
@@ -1,0 +1,122 @@
+﻿using ExpressionDebugger;
+using Mapster;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.OData;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Sample.AspNetCore.Controllers;
+using Sample.AspNetCore.Models;
+using System.Linq.Expressions;
+using System.Reflection;
+#if NET6_0
+using Hellang.Middleware.ProblemDetails;
+#endif
+
+namespace Sample.AspNetCore
+{
+    /// <summary>
+    /// Example Startup class demonstrating the enhanced Mapster DI configuration.
+    /// This is an alternative to the default Startup.cs showing the new features.
+    /// </summary>
+    public class StartupEnhanced
+    {
+        public StartupEnhanced(IConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+
+        public IConfiguration Configuration { get; }
+
+        // This method gets called by the runtime. Use this method to add services to the container.
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddControllers(opts => opts.EnableEndpointRouting = false)
+                .AddOData(options => options.Select().Filter().OrderBy())
+                .AddNewtonsoftJson();
+            services.AddDbContext<SchoolContext>(options =>
+                options.UseSqlServer(Configuration.GetConnectionString("DefaultConnection")));
+
+            // Register NameFormatter for use in mappings
+            services.AddSingleton<NameFormatter>();
+
+            // NEW: Enhanced Mapster configuration with multiple options
+            services.AddMapster(options =>
+            {
+                // Scan assemblies for IRegister and IMapFrom implementations
+                options.AssembliesToScan.Add(Assembly.GetExecutingAssembly());
+
+                // Use ServiceMapper for DI support (default: true)
+                options.UseServiceMapper = true;
+
+                // Configure inline mappings
+                options.ConfigureAction = config =>
+                {
+                    // Set custom compiler for debugging
+                    config.Compiler = exp => exp.CompileWithDebugInfo(
+                        new ExpressionCompilationOptions
+                        {
+                            EmitFile = true,
+                            ThrowOnFailedCompilation = true
+                        });
+
+                    // Configure mappings with DI
+                    config.NewConfig<Enrollment, EnrollmentDto>()
+                        .AfterMappingAsync(async dto =>
+                        {
+                            var context = MapContext.Current.GetService<SchoolContext>();
+                            var course = await context.Courses.FindAsync(dto.CourseID);
+                            if (course != null)
+                                dto.CourseTitle = course.Title;
+                            var student = await context.Students.FindAsync(dto.StudentID);
+                            if (student != null)
+                                dto.StudentName = MapContext.Current
+                                    .GetService<NameFormatter>()
+                                    .Format(student.FirstMidName, student.LastName);
+                        });
+
+                    config.NewConfig<Student, StudentDto>()
+                        .Map(dest => dest.Name,
+                             src => MapContext.Current
+                                .GetService<NameFormatter>()
+                                .Format(src.FirstMidName, src.LastName));
+
+                    config.NewConfig<Course, CourseDto>()
+                        .Map(dest => dest.CourseIDDto, src => src.CourseID)
+                        .Map(dest => dest.CreditsDto, src => src.Credits)
+                        .Map(dest => dest.TitleDto, src => src.Title)
+                        .Map(dest => dest.EnrollmentsDto, src => src.Enrollments);
+                };
+
+                // Precompile hot paths for better performance
+                options.TypePairsToPrecompile.Add((typeof(Student), typeof(StudentDto)));
+                options.TypePairsToPrecompile.Add((typeof(Course), typeof(CourseDto)));
+                options.TypePairsToPrecompile.Add((typeof(Enrollment), typeof(EnrollmentDto)));
+            });
+
+            // Alternative: Simple frozen configuration for production
+            // services.AddMapsterFrozen(config =>
+            // {
+            //     config.NewConfig<Student, StudentDto>();
+            //     config.NewConfig<Course, CourseDto>();
+            // });
+
+            // Alternative: Using assembly scanning only
+            // services.ScanMapster(Assembly.GetExecutingAssembly());
+
+            services.AddProblemDetails();
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+#if NET6_0
+            app.UseProblemDetails();
+#endif
+            app.UseRouting();
+            app.UseAuthorization();
+            app.UseMvc();
+        }
+    }
+}


### PR DESCRIPTION
## Overview

This update significantly enhances the Mapster dependency injection system with a comprehensive configuration API inspired by AutoMapper's `AddAutoMapper` method, while maintaining full backward compatibility with existing code. This package provides enhanced dependency injection and configuration support for Mapster, making it easier to integrate with ASP.NET Core applications.

## Key Improvements

### 1. Fluent Configuration API

Instead of manually creating and configuring `TypeAdapterConfig` outside of DI, you can now configure Mapster inline:

```csharp
// Old way (still works)
var config = new TypeAdapterConfig();
config.NewConfig<Source, Destination>();
services.AddSingleton(config);
services.AddScoped<IMapper, ServiceMapper>();

// New way
services.AddMapster(config =>
{
    config.NewConfig<Source, Destination>();
});
```

### 2. Assembly Scanning

Automatically discover and register mapping configurations:

```csharp
services.AddMapster(options =>
{
    options.AssembliesToScan.Add(Assembly.GetExecutingAssembly());
});
```

Supports both existing patterns:
- `IRegister` - Existing pattern for mapping configurations
- `IMapFrom<T>` - New pattern allowing DTOs to define their own mappings

### 3. ServiceMapper by Default

The new API uses `ServiceMapper` by default, providing full dependency injection support in mappings:

```csharp
config.NewConfig<User, UserDto>()
    .Map(dest => dest.DisplayName, 
         src => MapContext.Current.GetService<IUserService>().GetDisplayName(src));
```

### 4. Precompilation Support

Precompile frequently used mappings at startup for better runtime performance:

```csharp
services.AddMapster(options =>
{
    options.TypePairsToPrecompile.Add((typeof(User), typeof(UserDto)));
    options.TypePairsToPrecompile.Add((typeof(Product), typeof(ProductDto)));
});
```

### 5. Frozen Configuration

Lock configuration for maximum performance in production:

```csharp
services.AddMapsterFrozen(config =>
{
    config.NewConfig<User, UserDto>();
    config.NewConfig<Product, ProductDto>();
});
```

### 6. Module System

Create reusable, testable mapping configurations:

```csharp
public class UserMappingModule : IMapsterModule
{
    public void Register(TypeAdapterConfig config)
    {
        config.NewConfig<User, UserDto>()
            .Map(dest => dest.FullName, src => $"{src.FirstName} {src.LastName}");
    }
}

services.AddMapsterModule<UserMappingModule>();
```

### 7. Build Hooks

Execute logic before and after compilation:

```csharp
services.AddMapster(
    config => { /* configure */ },
    actions =>
    {
        actions.OnBeforeCompile = cfg => { /* pre-compilation logic */ };
        actions.OnAfterCompile = cfg => { /* post-compilation logic */ };
    });
```

### 8. MapContext Factory

Customize how MapContext scopes are created:

```csharp
public class CustomMapContextFactory : IMapContextFactory
{
    public IDisposable CreateScope(IServiceProvider serviceProvider)
    {
        // Custom scope creation logic
    }
}

services.AddSingleton<IMapContextFactory, CustomMapContextFactory>();
```

## Quick Start

### Basic Usage (Backward Compatible)

```csharp
services.AddMapster();
```

### With Inline Configuration

```csharp
services.AddMapster(config =>
{
    config.NewConfig<Source, Destination>()
        .Map(dest => dest.FullName, src => $"{src.FirstName} {src.LastName}");
});
```

### With Options

```csharp
services.AddMapster(options =>
{
    // Configure mappings
    options.ConfigureAction = config =>
    {
        config.NewConfig<Source, Destination>()
            .Map(dest => dest.FullName, src => $"{src.FirstName} {src.LastName}");
    };

    // Scan assemblies for IRegister and IMapFrom<T> implementations
    options.AssembliesToScan.Add(Assembly.GetExecutingAssembly());

    // Precompile specific type pairs for better performance
    options.TypePairsToPrecompile.Add((typeof(Source), typeof(Destination)));

    // Use ServiceMapper for DI support (default: true)
    options.UseServiceMapper = true;

    // Freeze configuration after setup (optional)
    options.FreezeConfiguration = false;
});
```

### Frozen Configuration (High Performance)

```csharp
services.AddMapsterFrozen(config =>
{
    config.NewConfig<Source, Destination>()
        .Map(dest => dest.FullName, src => $"{src.FirstName} {src.LastName}");
});
```

### With Build Actions

```csharp
services.AddMapster(
    config =>
    {
        config.NewConfig<Source, Destination>()
            .Map(dest => dest.FullName, src => $"{src.FirstName} {src.LastName}");
    },
    actions =>
    {
        actions.OnBeforeCompile = cfg => {
            // Execute logic before compilation
        };
        actions.OnAfterCompile = cfg => {
            // Execute logic after compilation
        };
        actions.PrecompileTypePairs = true;
        actions.Freeze = false;
    });
```

### Using Modules

```csharp
// Define a module
public class UserMappingModule : IMapsterModule
{
    public void Register(TypeAdapterConfig config)
    {
        config.NewConfig<User, UserDto>()
            .Map(dest => dest.FullName, src => $"{src.FirstName} {src.LastName}");
    }
}

// Register the module
services.AddMapsterModule<UserMappingModule>();
```

### Assembly Scanning

```csharp
// Scan current assembly
services.ScanMapster(Assembly.GetExecutingAssembly());

// Or specify multiple assemblies
services.ScanMapster(
    Assembly.GetExecutingAssembly(),
    typeof(SomeType).Assembly
);
```

## Pattern Support

### IRegister Pattern (Existing)

```csharp
public class UserMappingRegister : IRegister
{
    public void Register(TypeAdapterConfig config)
    {
        config.NewConfig<User, UserDto>()
            .Map(dest => dest.FullName, src => $"{src.FirstName} {src.LastName}");
    }
}
```

### IMapFrom<T> Pattern (New)

```csharp
public class UserDto : IMapFrom<User>
{
    public string FullName { get; set; }

    public void ConfigureMapping(TypeAdapterConfig config)
    {
        config.NewConfig<User, UserDto>()
            .Map(dest => dest.FullName, src => $"{src.FirstName} {src.LastName}");
    }
}
```

## Advanced Scenarios

### Custom MapContext Factory

```csharp
services.AddSingleton<IMapContextFactory, CustomMapContextFactory>();
```

### Combining Multiple Configurations

```csharp
services.AddMapster(options =>
{
    options.AssembliesToScan.Add(Assembly.GetExecutingAssembly());
    options.Modules.Add(new UserMappingModule());
    options.TypePairsToPrecompile.Add((typeof(User), typeof(UserDto)));
    options.FreezeConfiguration = true;
    options.ConfigureAction = config =>
    {
        // Additional inline configuration
        config.Default.IgnoreNullValues(true);
    };
});
```

## API Reference

### MapsterOptions

- `AssembliesToScan`: Assemblies to scan for mapping configurations
- `TypePairsToPrecompile`: Type pairs to precompile
- `UseServiceMapper`: Use ServiceMapper (true) or basic Mapper (false)
- `FreezeConfiguration`: Freeze config after build
- `ConfigureAction`: Action to configure TypeAdapterConfig
- `Modules`: Modules to register

### MapsterBuildActions

- `OnBeforeCompile`: Action executed before compilation
- `OnAfterCompile`: Action executed after compilation
- `ScanAssemblies`: Enable assembly scanning
- `PrecompileTypePairs`: Enable type pair precompilation
- `Freeze`: Freeze configuration

### Extension Methods

- `AddMapster()`: Basic registration (backward compatible)
- `AddMapster(Action<MapsterOptions>)`: Register with options
- `AddMapster(Action<TypeAdapterConfig>, Action<MapsterBuildActions>)`: Register with config and actions
- `AddMapsterWithConfig(TypeAdapterConfig, Action<MapsterBuildActions>)`: Use existing config
- `AddMapsterFrozen(Action<TypeAdapterConfig>)`: Register with frozen config
- `AddMapsterModule<TModule>()`: Register a module
- `ScanMapster(params Assembly[])`: Scan assemblies

## Migration Guide

### Minimal Migration (No Changes Required)

Your existing code continues to work without any changes:

```csharp
services.AddMapster(); // Still works exactly as before
```

### Recommended Migration

To take advantage of new features, update your code to:

```csharp
services.AddMapster(options =>
{
    options.AssembliesToScan.Add(Assembly.GetExecutingAssembly());
    options.UseServiceMapper = true; // Default, but explicit
});
```

### Full Feature Migration

For maximum benefits:

```csharp
services.AddMapster(options =>
{
    // Scan for mappings
    options.AssembliesToScan.Add(Assembly.GetExecutingAssembly());

    // Precompile hot paths
    options.TypePairsToPrecompile.Add((typeof(User), typeof(UserDto)));

    // Configure inline
    options.ConfigureAction = config =>
    {
        config.Default.IgnoreNullValues(true);
    };

    // Use ServiceMapper for DI
    options.UseServiceMapper = true;

    // Freeze for production
    options.FreezeConfiguration = Environment.IsProduction();
});
```


# Mapster.DependencyInjection - Usage Examples

## Example 1: Simple ASP.NET Core Setup

```csharp
// Program.cs or Startup.cs
public class Program
{
    public static void Main(string[] args)
    {
        var builder = WebApplication.CreateBuilder(args);

        // Add Mapster with inline configuration
        builder.Services.AddMapster(config =>
        {
            config.NewConfig<User, UserDto>()
                .Map(dest => dest.FullName, src => $"{src.FirstName} {src.LastName}");
        });

        var app = builder.Build();
        app.MapControllers();
        app.Run();
    }
}

// Controller
[ApiController]
[Route("api/[controller]")]
public class UsersController : ControllerBase
{
    private readonly IMapper _mapper;

    public UsersController(IMapper mapper)
    {
        _mapper = mapper;
    }

    [HttpGet("{id}")]
    public async Task<ActionResult<UserDto>> GetUser(int id)
    {
        var user = await _userRepository.GetByIdAsync(id);
        var userDto = _mapper.Map<UserDto>(user);
        return Ok(userDto);
    }
}
```

## Example 2: Assembly Scanning with IRegister

```csharp
// Mapping configuration class
public class UserMappingConfig : IRegister
{
    public void Register(TypeAdapterConfig config)
    {
        config.NewConfig<User, UserDto>()
            .Map(dest => dest.FullName, src => $"{src.FirstName} {src.LastName}")
            .Map(dest => dest.Age, src => DateTime.Now.Year - src.BirthYear);
    }
}

// DI Setup
builder.Services.AddMapster(options =>
{
    options.AssembliesToScan.Add(Assembly.GetExecutingAssembly());
});
```

## Example 3: Using IMapFrom<T> Pattern

```csharp
// DTO with built-in mapping configuration
public class UserDto : IMapFrom<User>
{
    public string FullName { get; set; }
    public int Age { get; set; }

    public void ConfigureMapping(TypeAdapterConfig config)
    {
        config.NewConfig<User, UserDto>()
            .Map(dest => dest.FullName, src => $"{src.FirstName} {src.LastName}")
            .Map(dest => dest.Age, src => DateTime.Now.Year - src.BirthYear);
    }
}

// DI Setup - scanning will automatically find and configure IMapFrom implementations
builder.Services.ScanMapster(Assembly.GetExecutingAssembly());
```

## Example 4: Dependency Injection in Mappings

```csharp
// Service to be injected
public interface IUserService
{
    string GetUserDisplayName(User user);
}

public class UserService : IUserService
{
    public string GetUserDisplayName(User user)
    {
        return $"{user.Title} {user.FirstName} {user.LastName}";
    }
}

// Mapping configuration
builder.Services.AddScoped<IUserService, UserService>();
builder.Services.AddMapster(config =>
{
    config.NewConfig<User, UserDto>()
        .Map(dest => dest.DisplayName, 
             src => MapContext.Current.GetService<IUserService>().GetUserDisplayName(src));
});

// Usage in controller
public class UsersController : ControllerBase
{
    private readonly IMapper _mapper;

    public UsersController(IMapper mapper)
    {
        _mapper = mapper;
    }

    [HttpGet("{id}")]
    public async Task<ActionResult<UserDto>> GetUser(int id)
    {
        var user = await _userRepository.GetByIdAsync(id);
        // ServiceMapper automatically injects IServiceProvider into MapContext
        var userDto = _mapper.Map<UserDto>(user);
        return Ok(userDto);
    }
}
```

## Example 5: High-Performance Frozen Configuration

```csharp
// For production scenarios where configuration won't change
builder.Services.AddMapsterFrozen(config =>
{
    config.NewConfig<User, UserDto>();
    config.NewConfig<Product, ProductDto>();
    config.NewConfig<Order, OrderDto>();
});
```

## Example 6: Precompiling Hot Paths

```csharp
// Precompile frequently used mappings for better performance
builder.Services.AddMapster(options =>
{
    options.ConfigureAction = config =>
    {
        config.NewConfig<User, UserDto>();
        config.NewConfig<Product, ProductDto>();
    };

    // Precompile these mappings at startup
    options.TypePairsToPrecompile.Add((typeof(User), typeof(UserDto)));
    options.TypePairsToPrecompile.Add((typeof(Product), typeof(ProductDto)));
});
```

## Example 7: Modular Configuration

```csharp
// Define reusable modules
public class UserMappingModule : IMapsterModule
{
    public void Register(TypeAdapterConfig config)
    {
        config.NewConfig<User, UserDto>()
            .Map(dest => dest.FullName, src => $"{src.FirstName} {src.LastName}");

        config.NewConfig<UserDto, User>()
            .Map(dest => dest.FirstName, src => src.FullName.Split(' ')[0])
            .Map(dest => dest.LastName, src => src.FullName.Split(' ')[1]);
    }
}

public class ProductMappingModule : IMapsterModule
{
    public void Register(TypeAdapterConfig config)
    {
        config.NewConfig<Product, ProductDto>();
        config.NewConfig<ProductDto, Product>();
    }
}

// Register modules
builder.Services.AddMapster(options =>
{
    options.Modules.Add(new UserMappingModule());
    options.Modules.Add(new ProductMappingModule());
});

// Or use generic method
builder.Services.AddMapsterModule<UserMappingModule>();
```

## Example 8: Build Hooks for Logging

```csharp
builder.Services.AddMapster(
    config =>
    {
        config.NewConfig<User, UserDto>();
    },
    actions =>
    {
        actions.OnBeforeCompile = cfg =>
        {
            _logger.LogInformation("Starting Mapster compilation...");
        };

        actions.OnAfterCompile = cfg =>
        {
            _logger.LogInformation("Mapster compilation completed.");
        };

        actions.PrecompileTypePairs = true;
        actions.Freeze = true;
    });
```

## Example 9: Combining Multiple Configurations

```csharp
builder.Services.AddMapster(options =>
{
    // Scan for IRegister and IMapFrom
    options.AssembliesToScan.Add(Assembly.GetExecutingAssembly());
    options.AssembliesToScan.Add(typeof(ExternalDto).Assembly);

    // Add modules
    options.Modules.Add(new CoreMappingModule());

    // Precompile hot paths
    options.TypePairsToPrecompile.Add((typeof(User), typeof(UserDto)));
    options.TypePairsToPrecompile.Add((typeof(Product), typeof(ProductDto)));

    // Global configuration
    options.ConfigureAction = config =>
    {
        config.Default.IgnoreNullValues(true);
        config.Default.MapToConstructor(true);
    };

    // Enable ServiceMapper for DI
    options.UseServiceMapper = true;

    // Freeze for production
    options.FreezeConfiguration = true;
});
```

## Example 10: Using Existing Configuration

```csharp
// Create configuration elsewhere
var config = new TypeAdapterConfig();
config.NewConfig<User, UserDto>();

// Apply additional configuration from modules
var module = new UserMappingModule();
module.Register(config);

// Use the existing configuration
builder.Services.AddMapsterWithConfig(config, actions =>
{
    actions.Freeze = true;
});
```

## Example 11: Conditional Configuration by Environment

```csharp
builder.Services.AddMapster(options =>
{
    options.ConfigureAction = config =>
    {
        config.NewConfig<User, UserDto>();
    };

    // Only freeze in production
    options.FreezeConfiguration = builder.Environment.IsProduction();

    // Only precompile in production
    if (builder.Environment.IsProduction())
    {
        options.TypePairsToPrecompile.Add((typeof(User), typeof(UserDto)));
    }
});
```

## Example 12: Testing Configuration

```csharp
[TestClass]
public class MappingTests
{
    [TestMethod]
    public void User_Should_Map_To_UserDto()
    {
        // Arrange
        var services = new ServiceCollection();
        services.AddMapster(config =>
        {
            config.NewConfig<User, UserDto>()
                .Map(dest => dest.FullName, src => $"{src.FirstName} {src.LastName}");
        });

        var serviceProvider = services.BuildServiceProvider();
        var mapper = serviceProvider.GetRequiredService<IMapper>();

        var user = new User
        {
            FirstName = "John",
            LastName = "Doe"
        };

        // Act
        var userDto = mapper.Map<UserDto>(user);

        // Assert
        Assert.AreEqual("John Doe", userDto.FullName);
    }
}
```

## Backward Compatibility

-  All existing code continues to work without changes
-  Existing `AddMapster()` method preserved
-  No breaking changes to public API
-  ServiceMapper can be disabled: `options.UseServiceMapper = false`